### PR TITLE
Make consul auto configuration conditional

### DIFF
--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigBootstrapConfiguration.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigBootstrapConfiguration.java
@@ -1,6 +1,7 @@
 package org.springframework.cloud.consul.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.config.client.ConfigClientProperties;
 import org.springframework.cloud.consul.ConsulAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -13,6 +14,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
  */
 @Configuration
 @Import(ConsulAutoConfiguration.class)
+@ConditionalOnProperty(name = "spring.consul.enabled", matchIfMissing = true)
 public class ConsulConfigBootstrapConfiguration {
 
 	@Autowired

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulAutoConfiguration.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulAutoConfiguration.java
@@ -2,6 +2,7 @@ package org.springframework.cloud.consul;
 
 import com.ecwid.consul.v1.ConsulClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +12,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @EnableConfigurationProperties
+@ConditionalOnProperty(name = "spring.consul.enabled", matchIfMissing = true)
 public class ConsulAutoConfiguration {
 
     @Bean


### PR DESCRIPTION
In some cases it's desirable to disable Consul auto configuration. For example, when running a service that uses spring-cloud-consul-config, you currently have to have a Consul server running or the application context fails to load. It would be nice to be able to disable the Consul auto configuration in these cases.

This PR uses `@ConditionalOnProperty(name = "consul.enabled", matchIfMissing = true)` to trigger creation of the various Consul components.