### PR TITLE
List service nodes filtered by alive, when getting the server list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <module>spring-cloud-consul-bus</module>
         <module>spring-cloud-consul-sample</module>
         <module>spring-cloud-consul-tests</module>
+        <module>spring-cloud-consul-utils</module>
 		<module>docs</module>
     </modules>
 

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/client/AgentClient.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/client/AgentClient.java
@@ -2,8 +2,10 @@ package org.springframework.cloud.consul.client;
 
 import feign.Param;
 import feign.RequestLine;
+import org.springframework.cloud.consul.model.Member;
 import org.springframework.cloud.consul.model.Service;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -22,4 +24,7 @@ public interface AgentClient {
 
     @RequestLine("PUT /v1/agent/service/deregister/{serviceId}")
     void deregister(@Param("serviceId") String serviceId);
+
+    @RequestLine("GET /v1/agent/members")
+    List<Member> getMembers();
 }

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/Member.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/Member.java
@@ -1,0 +1,55 @@
+package org.springframework.cloud.consul.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A serf/consul cluster member.
+ * @author nicu on 10.03.2015.
+ */
+@Data
+@EqualsAndHashCode(of = {"name", "address", "port"})
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Member {
+
+    @JsonProperty("Name")
+    private String name;
+
+    @JsonProperty("Addr")
+    private String address;
+
+    @JsonProperty("Port")
+    private int port;
+
+    @JsonProperty("Tags")
+    @JsonDeserialize(as = HashMap.class, keyAs = String.class, contentAs = String.class)
+    private Map<String, String> tags;
+
+    @JsonProperty("Status")
+    private int status;
+
+    @JsonProperty("ProtocolMin")
+    private int protocolMin;
+
+    @JsonProperty("ProtocolMax")
+    private int protocolMax;
+
+    @JsonProperty("ProtocolCur")
+    private int protocolCur;
+
+    @JsonProperty("DelegateMin")
+    private int delegateMin;
+
+    @JsonProperty("DelegateMax")
+    private int delegateMax;
+
+    @JsonProperty("DelegateCur")
+    private int delegateCur;
+
+}

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/SerfStatusEnum.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/SerfStatusEnum.java
@@ -1,0 +1,22 @@
+package org.springframework.cloud.consul.model;
+
+/**
+ * Gossip pool (serf) statuses.
+ * Created by nicu on 10.03.2015.
+ */
+public enum SerfStatusEnum {
+    StatusAlive(1),
+    StatusLeaving(2),
+    StatusLeft(3),
+    StatusFailed(4);
+    private final int code;
+
+    SerfStatusEnum(int code) {
+        this.code=code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+    
+}

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServer.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServer.java
@@ -9,9 +9,11 @@ import org.springframework.cloud.consul.model.ServiceNode;
 public class ConsulServer extends Server {
 
     private final MetaInfo metaInfo;
+    private final String address;
 
     public ConsulServer(final ServiceNode node) {
         super(node.getNode(), node.getServicePort());
+        address = node.getAddress();
         metaInfo = new MetaInfo() {
             @Override
             public String getAppName() {
@@ -38,5 +40,9 @@ public class ConsulServer extends Server {
     @Override
     public MetaInfo getMetaInfo() {
         return metaInfo;
+    }
+
+    public String getAddress() {
+        return address;
     }
 }

--- a/spring-cloud-consul-utils/pom.xml
+++ b/spring-cloud-consul-utils/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>spring-cloud-consul</artifactId>
+        <groupId>org.springframework.cloud</groupId>
+        <version>1.0.0.BUILD-SNAPSHOT</version>
+        <relativePath>../spring-cloud-consul-sample/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <name>Spring Cloud Consul Utils</name>
+
+    <artifactId>spring-cloud-consul-utils</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-consul-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-consul-discovery</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-consul-bus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/spring-cloud-consul-utils/src/main/java/org/springframework/cloud/consul/alive/AliveFilteringContext.java
+++ b/spring-cloud-consul-utils/src/main/java/org/springframework/cloud/consul/alive/AliveFilteringContext.java
@@ -1,0 +1,52 @@
+package org.springframework.cloud.consul.alive;
+
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ServerListFilter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.consul.discovery.ConsulServer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Injects a server list filter for giving servers hosting a service only for the live servers per serf status.
+ * @author nicu marasoiu on 10.03.2015.
+ */
+@Configuration
+@ComponentScan
+public class AliveFilteringContext {
+    @Bean
+    @Autowired
+    public ServerListFilter<Server> aliveServerListFilter(FilteringAgentClient filteringAgentClient) {
+        return adapter(new AliveServerListFilter(filteringAgentClient));
+    }
+
+    private ServerListFilter<Server> adapter(final ServerListFilter<ConsulServer> consulServerList) {
+
+        return new ServerListFilter<Server>() {
+            @Override
+            public List<Server> getFilteredListOfServers(List<Server> servers) {
+                return adapt2(consulServerList.getFilteredListOfServers(adapt1(servers)));
+            }
+
+            private List<ConsulServer> adapt1(List<Server> servers) {
+                List<ConsulServer> consulServers = new ArrayList<ConsulServer>(servers.size());
+                for (Server consulServer : servers) {
+                    consulServers.add((ConsulServer) consulServer);
+                }
+                return consulServers;
+            }
+
+            private List<Server> adapt2(List<ConsulServer> consulServers) {
+                List<Server> servers = new ArrayList<Server>(consulServers.size());
+                for (ConsulServer consulServer : consulServers) {
+                    servers.add(consulServer);
+                }
+                return servers;
+            }
+        };
+    }
+}

--- a/spring-cloud-consul-utils/src/main/java/org/springframework/cloud/consul/alive/AliveServerListFilter.java
+++ b/spring-cloud-consul-utils/src/main/java/org/springframework/cloud/consul/alive/AliveServerListFilter.java
@@ -1,0 +1,37 @@
+package org.springframework.cloud.consul.alive;
+
+import com.netflix.loadbalancer.ServerListFilter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.consul.discovery.ConsulServer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Server filter: returns only alive servers.
+ * Each consul agent runs a serf agent which is a member of the serf gossip pool.
+ * The serf status (alive/failed/etc) is reflected in 2 consul APIs: in the agent API and in the catalog API.
+ * We prefer the agent API because it is most up to date (or perhaps we should intersect them and pick members that are liv in both).
+ * @author nicu marasoiu on 10.03.2015.
+ */
+public class AliveServerListFilter implements ServerListFilter<ConsulServer>{
+    private FilteringAgentClient filteringAgentClient;
+
+    @Autowired
+    public AliveServerListFilter(FilteringAgentClient filteringAgentClient) {
+        this.filteringAgentClient = filteringAgentClient;
+    }
+
+    @Override
+    public List<ConsulServer> getFilteredListOfServers(List<ConsulServer> servers) {
+        Set<String> liveNodes = filteringAgentClient.getAliveAgentsAddresses();
+        List<ConsulServer> filteredServers = new ArrayList<>();
+        for (ConsulServer server : servers) {
+            if (liveNodes.contains(server.getAddress())) {
+                filteredServers.add(server);
+            }
+        }
+        return filteredServers;
+    }
+}

--- a/spring-cloud-consul-utils/src/main/java/org/springframework/cloud/consul/alive/FilteringAgentClient.java
+++ b/spring-cloud-consul-utils/src/main/java/org/springframework/cloud/consul/alive/FilteringAgentClient.java
@@ -1,0 +1,21 @@
+package org.springframework.cloud.consul.alive;
+
+import org.springframework.cloud.consul.model.Member;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * A CatalogClient which decorates some methods of CatalogClient with filtering, retaining info pertaining to live nodes.
+ * @author nicu on 10.03.2015.
+ */
+public interface FilteringAgentClient {
+    /**
+     * @return the set of alive gossip pool members (client or server consul agents).
+     */
+    Collection<Member> getAliveAgents();
+    /**
+     * @return the set of alive gossip pool members addresses.
+     */
+    Set<String> getAliveAgentsAddresses();
+}

--- a/spring-cloud-consul-utils/src/main/java/org/springframework/cloud/consul/alive/FilteringAgentClientImpl.java
+++ b/spring-cloud-consul-utils/src/main/java/org/springframework/cloud/consul/alive/FilteringAgentClientImpl.java
@@ -1,0 +1,41 @@
+package org.springframework.cloud.consul.alive;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.consul.client.AgentClient;
+import org.springframework.cloud.consul.model.Member;
+import org.springframework.cloud.consul.model.SerfStatusEnum;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+public class FilteringAgentClientImpl implements FilteringAgentClient {
+    public static final int ALIVE_STATUS = SerfStatusEnum.StatusAlive.getCode();
+    private final AgentClient agentClient;
+
+    @Autowired
+    public FilteringAgentClientImpl(AgentClient agentClient) {
+        this.agentClient = agentClient;
+    }
+
+    @Override
+    public Collection<Member> getAliveAgents() {
+        List<Member> members = agentClient.getMembers();
+        List<Member> liveMembers = new ArrayList<>(members.size());
+        for (Member peer : members) {
+            if (peer.getStatus() == ALIVE_STATUS) {
+                liveMembers.add(peer);
+            }
+        }
+        return liveMembers;
+    }
+
+    @Override
+    public Set<String> getAliveAgentsAddresses() {
+        Set<String> addresses = new HashSet<String>();
+        for (Member server : getAliveAgents()) {
+            addresses.add(server.getAddress());
+        }
+        return addresses;
+    }
+}


### PR DESCRIPTION
Hi,

This is a first pull request.
Most of the code is in a new module, that anyone can pull in maven if they want it.
No modification to existing modules is done, only a few additions of fields and remote http call methods.
I can also create an issue/feature request to track this.

The main functional idea is that a new server list filter is added in a separate module, but which needs few additions in existing core ones.

The list of server serving a service will be filtered by serf status, so that only services hosted by "alive" members of the gossip pools are listed.

The next would be the ttl implementation.

Thank you and cheers!
Nicu