### PR TITLE
Send heartbeats at 2/3 of ttl

### DIFF
--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/client/AgentClient.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/client/AgentClient.java
@@ -2,6 +2,7 @@ package org.springframework.cloud.consul.client;
 
 import feign.Param;
 import feign.RequestLine;
+import org.springframework.cloud.consul.model.Check;
 import org.springframework.cloud.consul.model.Service;
 
 import java.util.Map;
@@ -28,5 +29,4 @@ public interface AgentClient {
 
     @RequestLine("GET /v1/agent/check/pass/service:{checkId}")
     void pass(@Param("checkId") String checkId);
-
 }

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/client/AgentClient.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/client/AgentClient.java
@@ -20,6 +20,13 @@ public interface AgentClient {
     @RequestLine("PUT /v1/agent/service/register")
     void register(Service service);
 
+    @RequestLine("PUT /v1/agent/check/register")
+    void register(Check check);
+
     @RequestLine("PUT /v1/agent/service/deregister/{serviceId}")
     void deregister(@Param("serviceId") String serviceId);
+
+    @RequestLine("GET /v1/agent/check/pass/service:{checkId}")
+    void pass(@Param("checkId") String checkId);
+
 }

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/Check.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/Check.java
@@ -1,5 +1,6 @@
 package org.springframework.cloud.consul.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
@@ -7,13 +8,23 @@ import lombok.Data;
  * @author Spencer Gibb
  */
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Check {
+    @JsonProperty("ID")
+    private String id;
+
+    @JsonProperty("Name")
+    private String name;
+
+    @JsonProperty("Notes")
+    private String notes;
+
     @JsonProperty("Script")
     private String script;
 
     @JsonProperty("Interval")
-    private int interval;
+    private String interval;
 
     @JsonProperty("TTL")
-    private int ttl;
+    private String ttl;
 }

--- a/spring-cloud-consul-core/src/test/java/org/springframework/cloud/consul/client/AgentClientIT.java
+++ b/spring-cloud-consul-core/src/test/java/org/springframework/cloud/consul/client/AgentClientIT.java
@@ -12,8 +12,10 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.UUID;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Spencer Gibb
@@ -25,37 +27,46 @@ import static org.junit.Assert.*;
 @SpringApplicationConfiguration(classes = TestClientConfiguration.class)
 public class AgentClientIT {
 
+    private static final String SERVICE_ID = "testId"+ UUID.randomUUID().toString();
+    private static final String SERVICE_NAME = "testId"+ UUID.randomUUID().toString();
+
     @Autowired
     AgentClient client;
 
     @Test
     public void test001RegisterService() {
         Service service = new Service();
-        service.setId("test1id");
-        service.setName("test1Name");
+        service.setId(SERVICE_ID);
+        service.setName(SERVICE_NAME);
         service.setPort(9999);
         service.setTags(Arrays.asList("test1tag1", "test1tag2"));
         Check check = new Check();
         check.setScript("/usr/local/bin/gtrue");
-        check.setInterval(60);
+        check.setInterval(60 + "s");
+        check.setTtl(10 + "s");
         service.setCheck(check);
         client.register(service);
     }
 
     @Test
-    public void test002GetServices() {
+    public void test002CheckIsThere() {
+        client.pass(SERVICE_ID);
+    }
+
+    @Test
+    public void test003GetServices() {
         Map<String, Service> services = client.getServices();
         assertNotNull("services was null", services);
         assertFalse("services was empty", services.isEmpty());
     }
 
     @Test
-    public void test003DeregisterService() {
-        client.deregister("test1id");
+    public void test004DeregisterService() {
+        client.deregister(SERVICE_ID);
     }
 
     @Test
-    public void test004GetSelf() {
+    public void test005GetSelf() {
         Map<String, Object> self = client.getSelf();
         assertNotNull("self was null", self);
     }

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClientConfiguration.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClientConfiguration.java
@@ -13,6 +13,11 @@ public class ConsulDiscoveryClientConfiguration {
         return new ConsulLifecycle();
     }
 
+    @Bean
+    public TtlScheduler ttlScheduler() {
+        return new TtlScheduler();
+    }
+
     /*@Bean
     public ConsulLoadBalancerClient consulLoadBalancerClient() {
         return new ConsulLoadBalancerClient();

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/TtlScheduler.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/TtlScheduler.java
@@ -1,0 +1,125 @@
+package org.springframework.cloud.consul.discovery;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.consul.client.AgentClient;
+import org.springframework.cloud.consul.model.Service;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+import javax.annotation.PreDestroy;
+import java.util.Map;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Created by nicu on 11.03.2015.
+ */
+@Slf4j
+public class TtlScheduler implements ApplicationContextAware {
+    private static final AtomicInteger _instances = new AtomicInteger();
+    private static final int DEFAULT_TTL = 3; // must be > 1
+    public static final int HEARTBEAT_INTERVAL_RATIO = 2 / 3;
+
+    private final ScheduledExecutorService ttlExecutor;
+    private volatile ScheduledFuture<?> scheduledFuture;
+    private final Thread shutdownThread;
+    private final Map<String, Service> servicesById;
+    private final AtomicBoolean isShuttingDown;
+    private final Runnable ttlPingThread;
+    private volatile int ttl;
+    private volatile int heartbeatInterval;
+
+    @Autowired
+    private AgentClient agentClient;
+
+    public TtlScheduler() {
+        if (_instances.addAndGet(1) > 1) {
+            throw new IllegalStateException("Expecting this to be used in singleton mode!");
+        }
+        //one thread to refresh ttl for each registered app to local agent is ok
+        ttlExecutor = Executors.newSingleThreadScheduledExecutor();
+        shutdownThread = new Thread(new Runnable() {
+            public void run() {
+                log.info("Shutting down the Executor Pool for TtlScheduler");
+                shutdownExecutorPool();
+            }
+        });
+        Runtime.getRuntime().addShutdownHook(shutdownThread);
+        servicesById = new ConcurrentHashMap<>();
+        isShuttingDown = new AtomicBoolean();
+        ttlPingThread = new TtlPingThread();
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext context) throws BeansException {
+        ttl = context.getEnvironment().getProperty("consul.ttl", Integer.class, DEFAULT_TTL);
+        ttl = Math.min(2, ttl);
+        // heartbeat at 2/3 ttl, but no later than ttl -1s and, (under lesser priority), no sooner than 1s from now
+        heartbeatInterval = Math.max(ttl - 1, Math.min(ttl * HEARTBEAT_INTERVAL_RATIO, 1));
+        scheduleTtlHeartbeat();
+    }
+
+    /**
+     * Add a service to the checks loop.
+     */
+    public void add(final Service service) {
+        servicesById.put(service.getId(), service);
+    }
+
+    public void remove(String serviceId) {
+        servicesById.remove(serviceId);
+    }
+
+    public int getTTL() {
+        return ttl;
+    }
+
+
+    private void schedule(int millis, Runnable command) {
+        ttlExecutor.schedule(command, millis, TimeUnit.MILLISECONDS);
+    }
+
+    private void scheduleTtlHeartbeat() {
+        scheduledFuture = ttlExecutor.scheduleAtFixedRate(
+                ttlPingThread,
+                0, heartbeatInterval,
+                TimeUnit.SECONDS);
+    }
+
+    private void shutdownExecutorPool() {
+        isShuttingDown.set(true);
+        ttlExecutor.shutdown();
+        try {
+            Runtime.getRuntime().removeShutdownHook(shutdownThread);
+        } catch (IllegalStateException ignored) {
+        }
+    }
+
+    class TtlPingThread implements Runnable {
+        public void run() {
+            try {
+                heartbeatServices();
+            } catch (Throwable e) {
+                log.error("Exception while trying to send heartbeat from application to consul local agent in due TTL", e);
+            }
+        }
+    }
+
+    void heartbeatServices() {
+        for (Service service : servicesById.values()) {
+            if (!isShuttingDown.get()) {
+                agentClient.pass(service.getId());
+            }
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(true);
+        }
+    }
+}


### PR DESCRIPTION
Sending heartbeats faster than expected ttl for 2 reasons:
- the clock drift
- consul agent should hear sooner than ttl, so that there is no race condition window in which service can be flagged as unavailable

Also, TTL is a global configuration. Setting ttl per service is not really needed in my opinion, but if you have a clean way to allow this, we can factor it in.
