### PR TITLE
Do not expose implement details in ConsulHealthIndicator

### DIFF
--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulHealthIndicator.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulHealthIndicator.java
@@ -27,6 +27,7 @@ import com.ecwid.consul.v1.ConsulClient;
 import com.ecwid.consul.v1.QueryParams;
 import com.ecwid.consul.v1.Response;
 import com.ecwid.consul.v1.agent.model.Self;
+import com.ecwid.consul.v1.agent.model.Self.Config;
 
 /**
  * @author Spencer Gibb
@@ -40,10 +41,15 @@ public class ConsulHealthIndicator extends AbstractHealthIndicator {
 	protected void doHealthCheck(Health.Builder builder) throws Exception {
 		try {
 			Response<Self> self = consul.getAgentSelf();
+			Config config = self.getValue().getConfig();
 			Response<Map<String, List<String>>> services = consul
 					.getCatalogServices(QueryParams.DEFAULT);
-			builder.up().withDetail("services", services.getValue())
-					.withDetail("agent", self.getValue());
+			builder.up()
+					.withDetail("services", services.getValue())
+					.withDetail("advertiseAddress", config.getDomain())
+					.withDetail("datacenter", config.getDatacenter())
+					.withDetail("domain", config.getDomain())
+					.withDetail("nodeName", config.getNodeName());
 		}
 		catch (Exception e) {
 			builder.down(e);

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulHealthIndicator.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulHealthIndicator.java
@@ -49,7 +49,9 @@ public class ConsulHealthIndicator extends AbstractHealthIndicator {
 					.withDetail("advertiseAddress", config.getDomain())
 					.withDetail("datacenter", config.getDatacenter())
 					.withDetail("domain", config.getDomain())
-					.withDetail("nodeName", config.getNodeName());
+					.withDetail("nodeName", config.getNodeName())
+					.withDetail("bindAddress", config.getBindAddress())
+					.withDetail("clientAddress", config.getClientAddress());
 		}
 		catch (Exception e) {
 			builder.down(e);


### PR DESCRIPTION
The ConsulHealthIndicator is currently exposing all consul agent attributes. See below.

```
    "consul": {
        "status": "UP",
        "services": {
            "consul": [],
            "consul-53": [
                "udp"
            ],
            "consul-8300": [],
            "consul-8400": [],
            "consul-8500": [],
            "spring-boot-admin": [],
            "spring-boot-admin-8080": [],
            "spring-boot-admin-8081": [],
            "spring-boot-admin: management": [
                "management"
            ],
            "springbootadmin_helloworld-8080": [
                "spring-boot-management"
            ],
            "springbootadmin_helloworld-8081": [
                "spring-boot-management"
            ]
        },
        "agent": {
            "config": {
                "bootstrap": true,
                "server": true,
                "datacenter": "dc1",
                "dataDir": "/data",
                "dnsRecursor": "",
                "domain": "consul.",
                "logLevel": "INFO",
                "nodeName": "192.168.99.100.xip.io",
                "clientAddress": "0.0.0.0",
                "bindAddress": "0.0.0.0",
                "advertiseAddress": "192.168.99.100",
                "ports": {
                    "DNS": 53,
                    "HTTP": 8500,
                    "HTTPS": -1,
                    "RPC": 8400,
                    "SerfLan": 8301,
                    "SerfWan": 8302,
                    "Server": 8300
                },
                "leaveOnTerm": false,
                "skipLeaveOnInt": false,
                "statsiteAddress": "",
                "protocol": 2,
                "enableDebug": false,
                "verifyIncoming": false,
                "verifyOutgoing": false,
                "caFile": "",
                "certFile": "",
                "keyFile": "",
                "startJoin": [],
                "uiDir": "/ui",
                "pidFile": "",
                "enableSyslog": false,
                "rejoinAfterLeave": false
            },
            "member": {
                "name": "192.168.99.100.xip.io",
                "address": "192.168.99.100",
                "port": 8301,
                "tags": {
                    "bootstrap": "1",
                    "build": "0.5.0: 0c7ca91c",
                    "dc": "dc1",
                    "port": "8300",
                    "role": "consul",
                    "vsn": "2",
                    "vsn_max": "2",
                    "vsn_min": "1"
                },
                "status": 1,
                "protocolMin": 1,
                "protocolMax": 2,
                "protocolCur": 2,
                "delegateMin": 2,
                "delegateMax": 4,
                "delegateCur": 4
            }
        }
    }
```

I can image that you want to expose a list of all services that are registered in Consul but I think it is not a good idea to expose all internal attributes. I have selected some attributes which could be useful for this health check.