### PR TITLE
Vault config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
 		<module>spring-cloud-consul-discovery</module>
 		<module>spring-cloud-consul-bus</module>
 		<module>spring-cloud-consul-ui</module>
+		<module>spring-cloud-vault-config</module>
 		<module>spring-cloud-consul-sample</module>
 		<module>spring-cloud-starter-consul</module>
 		<module>spring-cloud-starter-consul-bus</module>
@@ -96,6 +97,11 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-consul-ui</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-vault-config</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>

--- a/spring-cloud-consul-sample/pom.xml
+++ b/spring-cloud-consul-sample/pom.xml
@@ -49,22 +49,10 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-consul-all</artifactId>
 		</dependency>
-		<!--<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-consul-config</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-consul-discovery</artifactId>
+			<artifactId>spring-cloud-vault-config</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-consul-bus</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-consul-ui</artifactId>
-		</dependency>-->
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/spring-cloud-consul-sample/src/main/java/org/springframework/cloud/consul/sample/SampleConsulApplication.java
+++ b/spring-cloud-consul-sample/src/main/java/org/springframework/cloud/consul/sample/SampleConsulApplication.java
@@ -51,7 +51,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @EnableConfigurationProperties
 @Slf4j
-public class SampleApplication implements ApplicationListener<SimpleRemoteEvent> {
+public class SampleConsulApplication implements ApplicationListener<SimpleRemoteEvent> {
 
 	@Autowired
 	private LoadBalancerClient loadBalancer;
@@ -106,7 +106,7 @@ public class SampleApplication implements ApplicationListener<SimpleRemoteEvent>
 	}
 
 	public static void main(String[] args) {
-		SpringApplication.run(SampleApplication.class, args);
+		SpringApplication.run(SampleConsulApplication.class, args);
 	}
 
 	@Override

--- a/spring-cloud-vault-config/pom.xml
+++ b/spring-cloud-vault-config/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>spring-cloud-vault-config</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring Cloud Vault Config</name>
+	<description>Spring Cloud Vault Config</description>
+
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-consul</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-context</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<!-- Only needed at compile time -->
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultClient.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultClient.java
@@ -22,15 +22,12 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpStatusCodeException;
-import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 /**

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultClient.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultClient.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.vault.config;
+
+import java.util.Collections;
+import java.util.Map;
+
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * @author Spencer Gibb
+ */
+@RequiredArgsConstructor
+public class VaultClient {
+	public static final String VAULT_TOKEN = "X-Vault-Token";
+
+//	protected static final ParameterizedTypeReference<Map<String, String>> typeRef = new ParameterizedTypeReference<Map<String, String>>() { };
+
+	@Setter
+	private RestTemplate rest = new RestTemplate();
+
+	private final VaultConfigProperties properties;
+
+	public Map<String, String> read(String key) {
+		String url = String.format("%s://%s:%s/v1/{backend}/{key}",
+				properties.getScheme(), properties.getHost(), properties.getPort());
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add(VAULT_TOKEN, properties.getToken());
+		try {
+			ResponseEntity<VaultResponse> response = rest.exchange(url, HttpMethod.GET,
+					new HttpEntity<>(headers), VaultResponse.class, properties.getBackend(), key);
+
+			HttpStatus status = response.getStatusCode();
+			if (status == HttpStatus.OK) {
+				return response.getBody().getData();
+			}
+		} catch (HttpStatusCodeException e) {
+			if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+				return null;
+			}
+			throw e;
+		}
+
+		return Collections.emptyMap();
+	}
+}

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigBootstrapConfiguration.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigBootstrapConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.vault.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Spencer Gibb
+ */
+@Configuration
+@EnableConfigurationProperties
+@ConditionalOnProperty(name = "spring.cloud.vault.config.enabled", matchIfMissing = true)
+public class VaultConfigBootstrapConfiguration {
+
+	@Bean
+	public VaultClient vaultClient() {
+		return new VaultClient(vaultConfigProperties());
+	}
+
+	@Bean
+	public VaultConfigProperties vaultConfigProperties() {
+		return new VaultConfigProperties();
+	}
+
+	@Bean
+	public VaultPropertySourceLocator vaultPropertySourceLocator() {
+		return new VaultPropertySourceLocator(vaultClient(), vaultConfigProperties());
+	}
+}

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigBootstrapConfiguration.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigBootstrapConfiguration.java
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @EnableConfigurationProperties
-@ConditionalOnProperty(name = "spring.cloud.vault.config.enabled", matchIfMissing = true)
+@ConditionalOnProperty(name = "spring.cloud.vault.enabled", matchIfMissing = true)
 public class VaultConfigBootstrapConfiguration {
 
 	@Bean

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigProperties.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigProperties.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.vault.config;
+
+import lombok.Data;
+
+import org.hibernate.validator.constraints.NotEmpty;
+import org.hibernate.validator.constraints.Range;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author Spencer Gibb
+ */
+@ConfigurationProperties("spring.cloud.vault.config")
+@Data
+public class VaultConfigProperties {
+	private boolean enabled = true;
+
+	@NotEmpty
+	private String host = "127.0.0.1";
+
+	@Range(min = 1, max = 65535)
+	private int port = 8200;
+
+	private String scheme = "http";
+
+	@NotEmpty
+	private String backend = "secret";
+
+	@NotEmpty
+	private String defaultContext = "application";
+
+	@NotEmpty
+	private String profileSeparator = ",";
+
+	@NotEmpty
+	private String token;
+}

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigProperties.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultConfigProperties.java
@@ -25,7 +25,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * @author Spencer Gibb
  */
-@ConfigurationProperties("spring.cloud.vault.config")
+@ConfigurationProperties("spring.cloud.vault")
 @Data
 public class VaultConfigProperties {
 	private boolean enabled = true;

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultPropertySource.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultPropertySource.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.vault.config;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import lombok.extern.apachecommons.CommonsLog;
+
+import org.springframework.core.env.EnumerablePropertySource;
+
+/**
+ * @author Spencer Gibb
+ */
+@CommonsLog
+public class VaultPropertySource extends EnumerablePropertySource<VaultClient> {
+
+	private String context;
+
+	private Map<String, String> properties = new LinkedHashMap<>();
+
+	public VaultPropertySource(String context, VaultClient source) {
+		super(context, source);
+		this.context = context;
+	}
+
+	public void init() {
+		try {
+			Map<String, String> values = this.source.read(this.context);
+
+			if (values != null) {
+				properties.putAll(values);
+			}
+		} catch (Exception e) {
+			log.error("Unable to read properties from vault for key "+this.context, e);
+		}
+	}
+
+	@Override
+	public Object getProperty(String name) {
+		return properties.get(name);
+	}
+
+	@Override
+	public String[] getPropertyNames() {
+		Set<String> strings = properties.keySet();
+		return strings.toArray(new String[strings.size()]);
+	}
+}

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultPropertySourceLocator.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultPropertySourceLocator.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.vault.config;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
+import org.springframework.core.env.CompositePropertySource;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+
+/**
+ * @author Spencer Gibb
+ */
+public class VaultPropertySourceLocator implements PropertySourceLocator {
+
+	private VaultClient vault;
+
+	private VaultConfigProperties properties;
+
+	public VaultPropertySourceLocator(VaultClient vault, VaultConfigProperties properties) {
+		this.vault = vault;
+		this.properties = properties;
+	}
+
+	@Override
+	public PropertySource<?> locate(Environment environment) {
+		if (environment instanceof ConfigurableEnvironment) {
+			ConfigurableEnvironment env = (ConfigurableEnvironment) environment;
+			String appName = env.getProperty("spring.application.name");
+			List<String> profiles = Arrays.asList(env.getActiveProfiles());
+
+			List<String> contexts = new ArrayList<>();
+
+			String defaultContext = this.properties.getDefaultContext();
+			contexts.add(defaultContext);
+			addProfiles(contexts, defaultContext, profiles);
+
+			String baseContext = appName;
+			contexts.add(baseContext);
+			addProfiles(contexts, baseContext, profiles);
+
+			Collections.reverse(contexts);
+
+			CompositePropertySource composite = new CompositePropertySource("vault");
+
+			for (String propertySourceContext : contexts) {
+				VaultPropertySource propertySource = create(propertySourceContext);
+				propertySource.init();
+				composite.addPropertySource(propertySource);
+			}
+
+			return composite;
+		}
+		return null;
+	}
+
+	private VaultPropertySource create(String context) {
+		return new VaultPropertySource(context, vault);
+	}
+
+	private void addProfiles(List<String> contexts, String baseContext,
+			List<String> profiles) {
+		for (String profile : profiles) {
+			contexts.add(baseContext + this.properties.getProfileSeparator() + profile);
+		}
+	}
+}

--- a/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultResponse.java
+++ b/spring-cloud-vault-config/src/main/java/org/springframework/cloud/vault/config/VaultResponse.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.vault.config;
+
+import java.util.Map;
+
+import lombok.Data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author Spencer Gibb
+ */
+@Data
+public class VaultResponse {
+	private String auth;
+	private Map<String, String> data;
+	@JsonProperty("lease_duration")
+	private long leaseDuration;
+	@JsonProperty("lease_id")
+	private String leaseId;
+	private boolean renewable;
+}

--- a/spring-cloud-vault-config/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-vault-config/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+# Bootstrap Configuration
+org.springframework.cloud.bootstrap.BootstrapConfiguration=\
+org.springframework.cloud.vault.config.VaultConfigBootstrapConfiguration


### PR DESCRIPTION
A property source using [hashicorp vault](https://vaultproject.io)

To run

1. [Install vault](https://vaultproject.io/docs/install/index.html)
2. run `vault server -dev`
3. grab the root token from the output, looks something like `Root Token: 12aeacd6-00ef-b805-4bd1-9506cc339a80` and 
3. `export SPRING_CLOUD_VAULT_TOKEN=12aeacd6-00ef-b805-4bd1-9506cc339a80`
4. run `vault write secret/testConsulAppt value=world excited=yes info.test=testinfo number=1`
5. `./mvnw clean install`
6. run `java -jar ./spring-cloud-consul-sample/target/spring-cloud-consul-sample-1.0.0.BUILD-SNAPSHOT.jar`
7. visit http://localhost:8080/env or http://localhost:8080/info to see

@mstine @dsyer @joshlong 

Could be moved to any project (`spring-cloud-config`?).  I just put it here because consul and vault are by the same folks, no consul dependencies (though vault supports consul, zookeeper and etcd as backends).