### PR TITLE
add support for acl tokens in discovery and config

### DIFF
--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
@@ -37,4 +37,6 @@ public class ConsulConfigProperties {
 
 	@NotEmpty
 	private String profileSeparator = ",";
+
+	private String aclToken;
 }

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySource.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySource.java
@@ -37,12 +37,14 @@ import com.ecwid.consul.v1.kv.model.GetValue;
 public class ConsulPropertySource extends EnumerablePropertySource<ConsulClient> {
 
 	private String context;
+	private String aclToken;
 
 	private Map<String, String> properties = new LinkedHashMap<>();
 
-	public ConsulPropertySource(String context, ConsulClient source) {
+	public ConsulPropertySource(String context, ConsulClient source, String aclToken) {
 		super(context, source);
 		this.context = context;
+		this.aclToken = aclToken;
 
 		if (!this.context.endsWith("/")) {
 			this.context = this.context + "/";
@@ -50,8 +52,12 @@ public class ConsulPropertySource extends EnumerablePropertySource<ConsulClient>
 	}
 
 	public void init() {
-		Response<List<GetValue>> response = source.getKVValues(context,
-				QueryParams.DEFAULT);
+		Response<List<GetValue>> response;
+		if (aclToken == null) {
+			response = source.getKVValues(context, QueryParams.DEFAULT);
+		} else {
+			response = source.getKVValues(context, aclToken, QueryParams.DEFAULT);
+		}
 		List<GetValue> values = response.getValue();
 
 		if (values != null) {

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocator.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocator.java
@@ -77,7 +77,7 @@ public class ConsulPropertySourceLocator implements PropertySourceLocator {
 	}
 
 	private ConsulPropertySource create(String context) {
-		return new ConsulPropertySource(context, consul);
+		return new ConsulPropertySource(context, consul, properties.getAclToken());
 	}
 
 	private void addProfiles(List<String> contexts, String baseContext,

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
@@ -45,6 +45,8 @@ public class ConsulDiscoveryProperties {
 	@Setter(AccessLevel.PRIVATE)
 	private String[] hostInfo = initHostInfo();
 
+	private String aclToken;
+
 	private List<String> tags = new ArrayList<>();
 
 	private boolean enabled = true;

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
@@ -127,7 +127,11 @@ public class ConsulLifecycle extends AbstractDiscoveryLifecycle {
 
 	protected void register(NewService newService) {
 		log.info("Registering service with consul: {}", newService.toString());
-		client.agentServiceRegister(newService);
+		if (properties.getAclToken() == null) {
+			client.agentServiceRegister(newService);
+		} else {
+			client.agentServiceRegister(newService, properties.getAclToken());
+		}
 		if (ttlConfig.isEnabled() && ttlScheduler != null) {
 			ttlScheduler.add(newService);
 		}


### PR DESCRIPTION
Pull request against https://github.com/spring-cloud/spring-cloud-consul/issues/66

This establishes two different acl tokens, one for registering the service in discovery and one for retrieving keys in config.

At that point Ecwid/consul-api does not support tokens for deregistering services. I'll open a new issue with consul-api to address.

Also, I was unable to build this due to some upstream dependencies (spring-integration-bom) not being available.