### PR TITLE
Adds configurable kv watch and listener

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
                 <scope>import</scope>
                 <type>pom</type>
 			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-collections4</artifactId>
+				<version>4.0</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,11 +64,6 @@
                 <scope>import</scope>
                 <type>pom</type>
 			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-collections4</artifactId>
-				<version>4.0</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/spring-cloud-consul-config/pom.xml
+++ b/spring-cloud-consul-config/pom.xml
@@ -23,6 +23,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>com.ecwid.consul</groupId>
 			<artifactId>consul-api</artifactId>
 			<optional>true</optional>
@@ -30,6 +35,11 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-consul-core</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-cloud-consul-config/pom.xml
+++ b/spring-cloud-consul-config/pom.xml
@@ -38,6 +38,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-context</artifactId>
 			<optional>true</optional>

--- a/spring-cloud-consul-config/pom.xml
+++ b/spring-cloud-consul-config/pom.xml
@@ -38,11 +38,6 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-collections4</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-context</artifactId>
 			<optional>true</optional>

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
@@ -95,4 +95,8 @@ public class ConsulConfigProperties {
 		YAML;
 
 	}
+
+	private int kvWatchDelay = 10;
+
+	private long kvWatchTimeout = 2;
 }

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySource.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySource.java
@@ -167,4 +167,8 @@ public class ConsulPropertySource extends EnumerablePropertySource<ConsulClient>
 		Set<String> strings = properties.keySet();
 		return strings.toArray(new String[strings.size()]);
 	}
+	
+	public String getContext() {
+		return context;
+	}
 }

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulConfigWatch.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulConfigWatch.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.consul.config.watch;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceStrength;
+import org.apache.commons.collections4.map.ReferenceMap;
+import org.springframework.cloud.bootstrap.BootstrapApplicationListener;
+import org.springframework.cloud.consul.config.ConsulConfigProperties;
+import org.springframework.cloud.consul.config.ConsulPropertySource;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.CompositePropertySource;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import com.ecwid.consul.v1.QueryParams;
+import com.ecwid.consul.v1.Response;
+import com.ecwid.consul.v1.kv.model.GetValue;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static org.springframework.util.Base64Utils.decodeFromString;
+
+/**
+ * A kv store watch that publishes an EnvironmentChangeEvent whenever a value under one of the property sources is changed
+ * 
+ * @author Andrew DePompa
+ */
+@Slf4j
+public class ConsulConfigWatch implements ApplicationEventPublisherAware, EnvironmentAware {
+
+	private ApplicationEventPublisher publisher;
+
+	private ConfigurableEnvironment environment;
+
+	private Set<ConsulPropertySource> consulPropertySources = null;
+
+	private ConsulConfigProperties properties;
+	
+	private Map<String, BigInteger> kvIndexes = new ReferenceMap<String, BigInteger>(ReferenceStrength.SOFT, ReferenceStrength.SOFT);
+
+	public ConsulConfigWatch(ConsulConfigProperties properties) {
+		this.properties = properties;
+	}
+
+	@SuppressWarnings("boxing")
+	@Scheduled(fixedDelayString = "${spring.cloud.consul.config.kvWatchDelay:10}")
+	public void kvWatch() {
+		getConsulPropertySources();
+		Map<String, String> changedProps = new HashMap<>();
+		for (ConsulPropertySource source : consulPropertySources) {
+			long index = -1;
+			if(kvIndexes.get(source.getName()) != null) {
+				index = kvIndexes.get(source.getName()).longValue();
+			}
+			Response<List<GetValue>> response = source.getSource().getKVValues(source.getContext(),
+					new QueryParams(properties.getKvWatchTimeout(), index));
+			Long consulIndex = response.getConsulIndex();
+			if (consulIndex != null) {
+				kvIndexes.put(source.getName(), BigInteger.valueOf(consulIndex));
+				if (index != consulIndex) {
+					if (response.getValue() != null) {
+						Set<String> existingProps = new HashSet<String>(Arrays.asList(source.getPropertyNames()));
+						for (GetValue getValue : response.getValue()) {
+							if (getValue.getModifyIndex() > index) {
+								changedProps.put(getValue.getKey(), getValue.getValue() == null ? "" : new String(decodeFromString(getValue.getValue())));
+							}
+							existingProps.remove(getValue.getKey().replace(source.getContext(), "").replace("/", "."));
+						}
+						for(String key : existingProps){
+							changedProps.put(key, null);
+						}
+					}
+				}
+			}
+		}
+		if (changedProps.size() > 0) {
+			log.trace("Received kv update from consul: {}", changedProps.toString());
+			publisher.publishEvent(new ConsulKeyValueChangeEvent(changedProps));
+		}
+	}
+
+	private void getConsulPropertySources() {
+		if (consulPropertySources == null) {
+			consulPropertySources = new HashSet<ConsulPropertySource>();
+			if (environment.getPropertySources()
+					.get(BootstrapApplicationListener.BOOTSTRAP_PROPERTY_SOURCE_NAME) instanceof CompositePropertySource) {
+				CompositePropertySource bootstrapPropertySource = ((CompositePropertySource) environment.getPropertySources()
+						.get(BootstrapApplicationListener.BOOTSTRAP_PROPERTY_SOURCE_NAME));
+				if (bootstrapPropertySource != null) {
+					Collection<PropertySource<?>> sources = bootstrapPropertySource.getPropertySources();
+					for (PropertySource<?> source : sources) {
+						if (source.getName().equals("consul")) {
+							CompositePropertySource consulPropertySource = (CompositePropertySource) source;
+							for (PropertySource<?> consulSource : consulPropertySource.getPropertySources()) {
+								consulPropertySources.add((ConsulPropertySource) consulSource);
+							}
+							break;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	public void setEnvironment(Environment environment) {
+		if (environment instanceof ConfigurableEnvironment) {
+			this.environment = (ConfigurableEnvironment) environment;
+		}
+	}
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
+		this.publisher = publisher;
+	}
+}

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulConfigWatch.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulConfigWatch.java
@@ -76,6 +76,7 @@ public class ConsulConfigWatch implements ApplicationEventPublisherAware, Enviro
 		findConsulPropertySources();
 		Map<String, String> changedProps = new HashMap<>();
 		for (ConsulPropertySource source : consulPropertySources) {
+			source.init();
 			long index = -1;
 			if(kvIndexes.get(source.getName()) != null) {
 				index = kvIndexes.get(source.getName()).longValue();

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulConfigWatch.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulConfigWatch.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.springframework.cloud.bootstrap.BootstrapApplicationListener;
+import org.springframework.cloud.bootstrap.config.PropertySourceBootstrapConfiguration;
 import org.springframework.cloud.consul.config.ConsulConfigProperties;
 import org.springframework.cloud.consul.config.ConsulPropertySource;
 import org.springframework.context.ApplicationEventPublisher;
@@ -76,7 +76,6 @@ public class ConsulConfigWatch implements ApplicationEventPublisherAware, Enviro
 		findConsulPropertySources();
 		Map<String, String> changedProps = new HashMap<>();
 		for (ConsulPropertySource source : consulPropertySources) {
-			source.init();
 			long index = -1;
 			if(kvIndexes.get(source.getName()) != null) {
 				index = kvIndexes.get(source.getName()).longValue();
@@ -117,9 +116,9 @@ public class ConsulConfigWatch implements ApplicationEventPublisherAware, Enviro
 			}
 			consulPropertySources = new HashSet<ConsulPropertySource>();
 			if (environment.getPropertySources()
-					.get(BootstrapApplicationListener.BOOTSTRAP_PROPERTY_SOURCE_NAME) instanceof CompositePropertySource) {
+					.get(PropertySourceBootstrapConfiguration.BOOTSTRAP_PROPERTY_SOURCE_NAME) instanceof CompositePropertySource) {
 				CompositePropertySource bootstrapPropertySource = ((CompositePropertySource) environment.getPropertySources()
-						.get(BootstrapApplicationListener.BOOTSTRAP_PROPERTY_SOURCE_NAME));
+						.get(PropertySourceBootstrapConfiguration.BOOTSTRAP_PROPERTY_SOURCE_NAME));
 				if (bootstrapPropertySource != null) {
 					Collection<PropertySource<?>> sources = bootstrapPropertySource.getPropertySources();
 					for (PropertySource<?> source : sources) {

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulConfigWatchConfiguration.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulConfigWatchConfiguration.java
@@ -1,0 +1,36 @@
+package org.springframework.cloud.consul.config.watch;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.endpoint.RefreshEndpoint;
+import org.springframework.cloud.consul.ConsulAutoConfiguration;
+import org.springframework.cloud.consul.config.ConsulConfigProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@Import(ConsulAutoConfiguration.class)
+@EnableConfigurationProperties
+@EnableScheduling
+@ConditionalOnProperty(name = "spring.cloud.consul.config.watch", matchIfMissing = false)
+public class ConsulConfigWatchConfiguration {
+
+	@Autowired
+	ConsulConfigProperties consulConfigProperties;
+	
+	@Autowired
+    private RefreshEndpoint refreshEndpoint;
+
+	@Bean
+	public ConsulConfigWatch consulConfigWatch() {
+		return new ConsulConfigWatch(consulConfigProperties);
+	}
+	
+	@Bean
+	public ConsulConfigurationListener consulConfigurationListener() {
+		return new ConsulConfigurationListener(refreshEndpoint);
+	}
+}

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulConfigWatchConfiguration.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulConfigWatchConfiguration.java
@@ -23,7 +23,7 @@ public class ConsulConfigWatchConfiguration {
 
 	@Autowired
 	ConsulConfigProperties consulConfigProperties;
-	
+
 	@Autowired
 	private RefreshEndpoint refreshEndpoint;
 
@@ -31,7 +31,7 @@ public class ConsulConfigWatchConfiguration {
 	public ConsulConfigWatch consulConfigWatch() {
 		return new ConsulConfigWatch(consulConfigProperties);
 	}
-	
+
 	@Bean
 	public ConsulConfigurationListener consulConfigurationListener() {
 		return new ConsulConfigurationListener(refreshEndpoint);

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulConfigWatchConfiguration.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulConfigWatchConfiguration.java
@@ -1,6 +1,8 @@
 package org.springframework.cloud.consul.config.watch;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.Endpoint;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.consul.config.ConsulConfigBootstrapConfiguration;
@@ -16,6 +18,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableConfigurationProperties
 @EnableScheduling
 @ConditionalOnProperty(name = "spring.cloud.consul.config.watch", matchIfMissing = false)
+@ConditionalOnClass(Endpoint.class)
 public class ConsulConfigWatchConfiguration {
 
 	@Autowired

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulConfigWatchConfiguration.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulConfigWatchConfiguration.java
@@ -3,16 +3,16 @@ package org.springframework.cloud.consul.config.watch;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.endpoint.RefreshEndpoint;
-import org.springframework.cloud.consul.ConsulAutoConfiguration;
+import org.springframework.cloud.consul.config.ConsulConfigBootstrapConfiguration;
 import org.springframework.cloud.consul.config.ConsulConfigProperties;
+import org.springframework.cloud.endpoint.RefreshEndpoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
-@Import(ConsulAutoConfiguration.class)
+@Import(ConsulConfigBootstrapConfiguration.class)
 @EnableConfigurationProperties
 @EnableScheduling
 @ConditionalOnProperty(name = "spring.cloud.consul.config.watch", matchIfMissing = false)
@@ -22,7 +22,7 @@ public class ConsulConfigWatchConfiguration {
 	ConsulConfigProperties consulConfigProperties;
 	
 	@Autowired
-    private RefreshEndpoint refreshEndpoint;
+	private RefreshEndpoint refreshEndpoint;
 
 	@Bean
 	public ConsulConfigWatch consulConfigWatch() {

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulConfigurationListener.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulConfigurationListener.java
@@ -1,0 +1,22 @@
+package org.springframework.cloud.consul.config.watch;
+
+import org.springframework.cloud.endpoint.RefreshEndpoint;
+import org.springframework.context.ApplicationListener;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ConsulConfigurationListener implements ApplicationListener<ConsulKeyValueChangeEvent> {
+
+	private RefreshEndpoint refreshEndpoint;
+
+	public ConsulConfigurationListener(RefreshEndpoint refreshEndpoint) {
+		this.refreshEndpoint = refreshEndpoint;
+	}
+
+	@Override
+	public void onApplicationEvent(ConsulKeyValueChangeEvent event) {
+		log.trace("Received ConsulKeyValueChangeEvent. Refreshing...");
+		refreshEndpoint.refresh();
+	}
+}

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulKeyValueChangeEvent.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/watch/ConsulKeyValueChangeEvent.java
@@ -1,0 +1,21 @@
+package org.springframework.cloud.consul.config.watch;
+
+import java.util.Map;
+
+import org.springframework.context.ApplicationEvent;
+
+public class ConsulKeyValueChangeEvent extends ApplicationEvent {
+
+	private static final long serialVersionUID = 1L;
+
+	private Map<String, String> properties; 
+	
+	public ConsulKeyValueChangeEvent(Map<String, String> source) {
+		super(source);
+		properties = source;
+	}
+
+	public Map<String, String> getProperties(){
+		return properties;
+	}
+}

--- a/spring-cloud-consul-config/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-consul-config/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,7 @@
 # Bootstrap Configuration
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
 org.springframework.cloud.consul.config.ConsulConfigBootstrapConfiguration
+
+# Auto Configuration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.springframework.cloud.consul.config.watch.ConsulConfigWatchConfiguration

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigWatchTest.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigWatchTest.java
@@ -109,7 +109,6 @@ public class ConsulConfigWatchTest {
 		alterProperty(TEST_ADD_KEY, "new value");
 	}
 
-
 	@Test
 	public void addEmptyValue() throws InterruptedException{
 		alterProperty(TEST_ADD_KEY, "");

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigWatchTest.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigWatchTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.consul.config;
+
+import static org.springframework.cloud.consul.config.util.ConsulConfigTestUtil.*;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.ecwid.consul.v1.ConsulClient;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Andrew DePompa
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = { ConsulConfigWatchTest.MyTestConfig.class,
+		org.springframework.cloud.consul.config.util.ConsulConfigTestUtil.ConsulKeyValueChangeEventHandler.class })
+@WebIntegrationTest(value = { "spring.application.name=testConsulConfigWatch", "spring.cloud.consul.config.watch=true" }, randomPort = true)
+@Slf4j
+public class ConsulConfigWatchTest {
+	public final String TEST_CHANGE_KEY = "config/application/testChangeValue";
+	public final String TEST_ADD_KEY = "config/application/testAddValue";
+	public final String TEST_DOT_KEY = "config/application/test.add.value";
+	
+	@Autowired
+	private ConsulClient client;
+
+	@Before
+	public void setup() throws InterruptedException {
+		failMessage = DEFAULT_FAIL_MESSAGE;
+		client.setKVValue(TEST_CHANGE_KEY, "default value");
+
+		// wait a second to allow the watch to trigger without impacting the tests
+		Thread.sleep(1000);
+
+		testing = true;
+	}
+
+	@After
+	public void cleanup() {
+		testing = false;
+		client.deleteKVValue(TEST_ADD_KEY);
+		client.deleteKVValue(TEST_CHANGE_KEY);
+		client.deleteKVValue(TEST_DOT_KEY);
+	}
+
+	@Test
+	public void changePropertyTest() throws InterruptedException {
+		alterProperty(TEST_CHANGE_KEY, "hello world");
+	}
+
+	private void alterProperty(String key, String value) throws InterruptedException {
+		expectedKey = key;
+		expectedValue = value;
+		Thread.sleep(2000);
+		log.info("Changing value...");
+		client.setKVValue(key, value);
+		Thread.sleep(2000);
+
+		if (failMessage != null) {
+			Assert.fail(failMessage);
+		}
+	}
+
+	@Test
+	public void addPropertyTest() throws InterruptedException {
+		alterProperty(TEST_ADD_KEY, "new value");
+	}
+	
+
+	@Test 
+	public void addEmptyValue() throws InterruptedException{
+		alterProperty(TEST_ADD_KEY, "");
+	}
+	
+	@Test
+	public void addPropertyWithDotInKey() throws InterruptedException {
+		alterProperty(TEST_DOT_KEY, "value");
+	}
+	
+
+	@Configuration
+	@EnableAutoConfiguration
+	@ComponentScan
+	public static class MyTestConfig {
+		// ignore
+	}
+}

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigWatchTest.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigWatchTest.java
@@ -15,7 +15,11 @@
  */
 package org.springframework.cloud.consul.config;
 
-import static org.springframework.cloud.consul.config.util.ConsulConfigTestUtil.*;
+import static org.springframework.cloud.consul.config.util.ConsulConfigTestUtil.DEFAULT_FAIL_MESSAGE;
+import static org.springframework.cloud.consul.config.util.ConsulConfigTestUtil.expectedKey;
+import static org.springframework.cloud.consul.config.util.ConsulConfigTestUtil.expectedValue;
+import static org.springframework.cloud.consul.config.util.ConsulConfigTestUtil.failMessage;
+import static org.springframework.cloud.consul.config.util.ConsulConfigTestUtil.testing;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -46,7 +50,7 @@ public class ConsulConfigWatchTest {
 	public final String TEST_CHANGE_KEY = "config/application/testChangeValue";
 	public final String TEST_ADD_KEY = "config/application/testAddValue";
 	public final String TEST_DOT_KEY = "config/application/test.add.value";
-	
+
 	@Autowired
 	private ConsulClient client;
 
@@ -77,10 +81,23 @@ public class ConsulConfigWatchTest {
 	private void alterProperty(String key, String value) throws InterruptedException {
 		expectedKey = key;
 		expectedValue = value;
-		Thread.sleep(2000);
+		Thread.sleep(3000);
 		log.info("Changing value...");
 		client.setKVValue(key, value);
-		Thread.sleep(2000);
+		Thread.sleep(3000);
+
+		if (failMessage != null) {
+			Assert.fail(failMessage);
+		}
+	}
+
+	private void deleteProperty(String key) throws InterruptedException {
+		expectedKey = key;
+		expectedValue = "default value";
+		Thread.sleep(3000);
+		log.info("Deleting key...");
+		client.deleteKVValue(key);
+		Thread.sleep(3000);
 
 		if (failMessage != null) {
 			Assert.fail(failMessage);
@@ -91,18 +108,24 @@ public class ConsulConfigWatchTest {
 	public void addPropertyTest() throws InterruptedException {
 		alterProperty(TEST_ADD_KEY, "new value");
 	}
-	
 
-	@Test 
+
+	@Test
 	public void addEmptyValue() throws InterruptedException{
 		alterProperty(TEST_ADD_KEY, "");
 	}
-	
+
 	@Test
 	public void addPropertyWithDotInKey() throws InterruptedException {
 		alterProperty(TEST_DOT_KEY, "value");
 	}
-	
+
+	@Test
+	public void addRemoveValueTest() throws InterruptedException {
+		alterProperty(TEST_ADD_KEY, "some value");
+		failMessage = DEFAULT_FAIL_MESSAGE;
+		deleteProperty(TEST_ADD_KEY);
+	}
 
 	@Configuration
 	@EnableAutoConfiguration

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigWatchTestRemove.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigWatchTestRemove.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.consul.config;
+
+import static org.springframework.cloud.consul.config.util.ConsulConfigTestUtil.DEFAULT_FAIL_MESSAGE;
+import static org.springframework.cloud.consul.config.util.ConsulConfigTestUtil.expectedKey;
+import static org.springframework.cloud.consul.config.util.ConsulConfigTestUtil.expectedValue;
+import static org.springframework.cloud.consul.config.util.ConsulConfigTestUtil.failMessage;
+import static org.springframework.cloud.consul.config.util.ConsulConfigTestUtil.testing;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.ecwid.consul.v1.ConsulClient;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Separated the remove test from the others as the keys conflicted since the environment does not actually update in these tests
+ * 
+ * @author Andrew DePompa
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = { ConsulConfigWatchTestRemove.MyTestConfig.class,
+		org.springframework.cloud.consul.config.util.ConsulConfigTestUtil.ConsulKeyValueChangeEventHandler.class })
+@WebIntegrationTest(value = { "spring.application.name=testConsulConfigWatchRemove",
+		"spring.cloud.consul.config.watch=true" }, randomPort = true)
+@Slf4j
+public class ConsulConfigWatchTestRemove {
+	public final String TEST_DELETE_KEY = "config/application/testDeleteValue";
+	
+	@Autowired
+	private ConsulClient client;
+
+	@Before
+	public void setup() {
+		failMessage = DEFAULT_FAIL_MESSAGE;
+		client.setKVValue(TEST_DELETE_KEY, "default value");
+
+		testing = true;
+	}
+
+	@After
+	public void cleanup() {
+		testing = false;
+		client.deleteKVValue(TEST_DELETE_KEY);
+	}
+
+	private void deleteProperty(String key) throws InterruptedException {
+		expectedKey = key;
+		expectedValue = "default value";
+		Thread.sleep(2000);
+		log.info("Deleting key...");
+		client.deleteKVValue(key);
+		Thread.sleep(2000);
+
+		if (failMessage != null) {
+			Assert.fail(failMessage);
+		}
+	}
+
+	@Test
+	public void removeValueTest() throws InterruptedException {
+		deleteProperty(TEST_DELETE_KEY);
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	@ComponentScan
+	public static class MyTestConfig {
+		// ignore
+	}
+}

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigWatchTestRemove.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigWatchTestRemove.java
@@ -40,7 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * Separated the remove test from the others as the keys conflicted since the environment does not actually update in these tests
- * 
+ *
  * @author Andrew DePompa
  */
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -50,8 +50,9 @@ import lombok.extern.slf4j.Slf4j;
 		"spring.cloud.consul.config.watch=true" }, randomPort = true)
 @Slf4j
 public class ConsulConfigWatchTestRemove {
+	public final String TEST_ADD_KEY = "config/application/testAddValue";
 	public final String TEST_DELETE_KEY = "config/application/testDeleteValue";
-	
+
 	@Autowired
 	private ConsulClient client;
 

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/util/ConsulConfigTestUtil.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/util/ConsulConfigTestUtil.java
@@ -22,11 +22,6 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 
 /**
-<<<<<<< HEAD
- *
-=======
- *
->>>>>>> Adds configurable kv watch and listener
  * @author Andrew DePompa
  *
  */

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/util/ConsulConfigTestUtil.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/util/ConsulConfigTestUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.consul.config.util;
+
+import java.util.Map;
+
+import org.springframework.cloud.consul.config.watch.ConsulKeyValueChangeEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * 
+ * @author Andrew DePompa
+ *
+ */
+public class ConsulConfigTestUtil {
+	public static final String DEFAULT_FAIL_MESSAGE = "Listener never captured event";
+
+	public static String failMessage;
+	public static String expectedKey;
+	public static String expectedValue;
+	public static boolean testing = false;
+
+	@Bean
+	public ConsulKeyValueChangeEventHandler kvChangeEventHandler() {
+		return new ConsulKeyValueChangeEventHandler();
+	}
+
+	public static class ConsulKeyValueChangeEventHandler implements ApplicationListener<ConsulKeyValueChangeEvent> {
+		@Override
+		public void onApplicationEvent(ConsulKeyValueChangeEvent event) {
+			if (testing) {
+				Map<String, String> properties = event.getProperties();
+				if(properties == null){
+					failMessage = "ConsulKeyValueChangeEvent properties should not be null";
+				} else if (properties.size() != 1) {
+					failMessage = "ConsulKeyValueChangeEvent should have 1 key but had: " + properties.size() + " = " + properties.toString();
+				} else if (!properties.containsKey(expectedKey) && !properties.keySet().iterator().next().contains(expectedKey.substring(expectedKey.lastIndexOf('/')+1))) {
+					failMessage = "Event does not contain key = " + expectedKey + ": actual = " + properties.toString();
+				} else if(!properties.get(expectedKey).equals(expectedValue)) {
+					failMessage = "Event does not contain value = " + expectedValue + ": actual = " + properties.get(expectedKey); 
+				}
+				else {
+					failMessage = null;
+				}
+			}
+		}
+	}
+}

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/util/ConsulConfigTestUtil.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/util/ConsulConfigTestUtil.java
@@ -22,7 +22,11 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 
 /**
+<<<<<<< HEAD
  *
+=======
+ *
+>>>>>>> Adds configurable kv watch and listener
  * @author Andrew DePompa
  *
  */

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/util/ConsulConfigTestUtil.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/util/ConsulConfigTestUtil.java
@@ -22,7 +22,7 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 
 /**
- * 
+ *
  * @author Andrew DePompa
  *
  */
@@ -50,10 +50,9 @@ public class ConsulConfigTestUtil {
 					failMessage = "ConsulKeyValueChangeEvent should have 1 key but had: " + properties.size() + " = " + properties.toString();
 				} else if (!properties.containsKey(expectedKey) && !properties.keySet().iterator().next().contains(expectedKey.substring(expectedKey.lastIndexOf('/')+1))) {
 					failMessage = "Event does not contain key = " + expectedKey + ": actual = " + properties.toString();
-				} else if(!properties.get(expectedKey).equals(expectedValue)) {
-					failMessage = "Event does not contain value = " + expectedValue + ": actual = " + properties.get(expectedKey); 
-				}
-				else {
+				} else if(properties.get(expectedKey) != null && !properties.get(expectedKey).equals(expectedValue)) {
+					failMessage = "Event does not contain value = " + expectedValue + ": actual = " + properties.get(expectedKey);
+				} else {
 					failMessage = null;
 				}
 			}


### PR DESCRIPTION
Pulled fresh copy of project and added the kv watch on top. No more issues with 3 way merge. Also updated the event thrown to contain a full map of changed keys and values at the request of a user.