### PR TITLE
Added support to various formats in which configuration can be specified in consul

### DIFF
--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigFormat.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigFormat.java
@@ -46,7 +46,13 @@ public enum ConsulConfigFormat {
 	 * Indicates that the configuration specified in consul is of property style i.e.,
 	 * value of the consul key would be a list of key=value pairs separated by new lines.
 	 */
-	PROPERTIES;
+	PROPERTIES,
+
+	/**
+	 * Indicates that the configuration specified in consul is of YAML style i.e.,
+	 * value of the consul key would be YAML format
+	 */
+	YAML;
 
 	public static ConsulConfigFormat fromString(String value) {
 		if (value == null) {
@@ -55,6 +61,8 @@ public enum ConsulConfigFormat {
 			return ConsulConfigFormat.KEY_VALUE;
 		} else if (PROPERTIES.name().equals(value)) {
 			return ConsulConfigFormat.PROPERTIES;
+		} else if(YAML.name().equals(value)) {
+			return ConsulConfigFormat.YAML;
 		} else {
 			throw new IllegalArgumentException(
 				value + " cannot be decoded to any ConsulConfigFormat value");

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigFormat.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigFormat.java
@@ -1,0 +1,63 @@
+package org.springframework.cloud.consul.config;
+
+/**
+ * There are many ways in which we can specify configuration in consul i.e.,
+ *
+ * <ol>
+ *    <li>
+ *       Nested key value style: Where value is either a constant or part of the key (nested).
+ *       For e.g.,
+ *       For following configuration
+ *       a.b.c=something
+ *       a.b.d=something else
+ *       One can specify the configuration in consul with
+ *       key as "../kv/config/application/a/b/c" and value as "something" and
+ *       key as "../kv/config/application/a/b/d" and value as "something else"
+ *    </li>
+ *    <li>
+ *       Entire contents of properties file as value
+ *       For e.g.,
+ *       For following configuration
+ *       a.b.c=something
+ *       a.b.d=something else
+ *       One can specify the configuration in consul with
+ *       key as "../kv/config/application/properties" and value as whole configuration
+ *       "
+ *       a.b.c=something
+ *       a.b.d=something else
+ *       "
+ *    </li>
+ *    <li>
+ *       as Json or YML. You get it.
+ *    </li>
+ * </ol>
+ *
+ * This enum specifies the different Formats/styles supported for loading the configuration.
+ *
+ * @author srikalyan.swayampakula
+ */
+public enum ConsulConfigFormat {
+   /**
+    * Indicates that the configuration specified in consul is of type native key values.
+    */
+   KEY_VALUE,
+
+   /**
+    * Indicates that the configuration specified in consul is of property style i.e.,
+    * value of the consul key would be a list of key=value pairs separated by new lines.
+    */
+   PROPERTIES;
+
+   public static ConsulConfigFormat fromString(String value) {
+      if (value == null) {
+         return null;
+      } else if (KEY_VALUE.name().equals(value)) {
+         return ConsulConfigFormat.KEY_VALUE;
+      } else if (PROPERTIES.name().equals(value)) {
+         return ConsulConfigFormat.PROPERTIES;
+      } else {
+         throw new IllegalArgumentException(
+            value + " cannot be decoded to any ConsulConfigFormat value");
+      }
+   }
+}

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigFormat.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigFormat.java
@@ -37,27 +37,27 @@ package org.springframework.cloud.consul.config;
  * @author srikalyan.swayampakula
  */
 public enum ConsulConfigFormat {
-   /**
-    * Indicates that the configuration specified in consul is of type native key values.
-    */
-   KEY_VALUE,
+	/**
+	 * Indicates that the configuration specified in consul is of type native key values.
+	 */
+	KEY_VALUE,
 
-   /**
-    * Indicates that the configuration specified in consul is of property style i.e.,
-    * value of the consul key would be a list of key=value pairs separated by new lines.
-    */
-   PROPERTIES;
+	/**
+	 * Indicates that the configuration specified in consul is of property style i.e.,
+	 * value of the consul key would be a list of key=value pairs separated by new lines.
+	 */
+	PROPERTIES;
 
-   public static ConsulConfigFormat fromString(String value) {
-      if (value == null) {
-         return null;
-      } else if (KEY_VALUE.name().equals(value)) {
-         return ConsulConfigFormat.KEY_VALUE;
-      } else if (PROPERTIES.name().equals(value)) {
-         return ConsulConfigFormat.PROPERTIES;
-      } else {
-         throw new IllegalArgumentException(
-            value + " cannot be decoded to any ConsulConfigFormat value");
-      }
-   }
+	public static ConsulConfigFormat fromString(String value) {
+		if (value == null) {
+			return null;
+		} else if (KEY_VALUE.name().equals(value)) {
+			return ConsulConfigFormat.KEY_VALUE;
+		} else if (PROPERTIES.name().equals(value)) {
+			return ConsulConfigFormat.PROPERTIES;
+		} else {
+			throw new IllegalArgumentException(
+				value + " cannot be decoded to any ConsulConfigFormat value");
+		}
+	}
 }

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
@@ -42,8 +42,8 @@ public class ConsulConfigProperties {
 	private String consulConfigFormat = ConsulConfigFormat.KEY_VALUE.name();
 
 	/**
-	 * If consulConfigFormat is ConsulConfigFormat.PROPERTIES then the following field is used as key
-	 * to look up consul for configuration.
+	 * If consulConfigFormat is ConsulConfigFormat.PROPERTIES or ConsulConfigFormat.YAML
+	 * then the following field is used as key to look up consul for configuration.
 	 */
 	@NotEmpty
 	private String consulConfigPropertiesKey = "properties";

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
@@ -46,7 +46,7 @@ public class ConsulConfigProperties {
 	 * then the following field is used as key to look up consul for configuration.
 	 */
 	@NotEmpty
-	private String consulConfigPropertiesKey = "properties";
+	private String consulConfigDataKey = "data";
 
 	private String aclToken;
 }

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
@@ -38,5 +38,16 @@ public class ConsulConfigProperties {
 	@NotEmpty
 	private String profileSeparator = ",";
 
+	@NotEmpty
+   private String consulConfigFormat = ConsulConfigFormat.KEY_VALUE.name();
+
+   /**
+    * If consulConfigFormat is ConsulConfigFormat.PROPERTIES then the following field is used as key
+    * to look up consul for configuration.
+    */
+	@NotEmpty
+   private String consulConfigPropertiesKey = "properties";
+
+
 	private String aclToken;
 }

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
@@ -39,15 +39,14 @@ public class ConsulConfigProperties {
 	private String profileSeparator = ",";
 
 	@NotEmpty
-   private String consulConfigFormat = ConsulConfigFormat.KEY_VALUE.name();
+	private String consulConfigFormat = ConsulConfigFormat.KEY_VALUE.name();
 
-   /**
-    * If consulConfigFormat is ConsulConfigFormat.PROPERTIES then the following field is used as key
-    * to look up consul for configuration.
-    */
+	/**
+	 * If consulConfigFormat is ConsulConfigFormat.PROPERTIES then the following field is used as key
+	 * to look up consul for configuration.
+	 */
 	@NotEmpty
-   private String consulConfigPropertiesKey = "properties";
-
+	private String consulConfigPropertiesKey = "properties";
 
 	private String aclToken;
 }

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySource.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySource.java
@@ -114,7 +114,7 @@ public class ConsulPropertySource extends EnumerablePropertySource<ConsulClient>
 
 		for (GetValue getValue : values) {
 			String key = getValue.getKey().replace(context, "");
-			if (!consulConfigProperties.getConsulConfigPropertiesKey().equals(key)) {
+			if (!consulConfigProperties.getConsulConfigDataKey().equals(key)) {
 				continue;
 			}
 

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySource.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySource.java
@@ -67,69 +67,69 @@ public class ConsulPropertySource extends EnumerablePropertySource<ConsulClient>
 		}
 
 		final List<GetValue> values = response.getValue();
-      final ConsulConfigFormat consulConfigFormat =
-         ConsulConfigFormat.fromString(consulConfigProperties.getConsulConfigFormat());
-      if (consulConfigFormat == ConsulConfigFormat.KEY_VALUE) {
-         parsePropertiesInKeyValueFormat(values);
-      } else if (consulConfigFormat == ConsulConfigFormat.PROPERTIES) {
-         parsePropertiesInPropertiesFormat(values);
-      }
+		final ConsulConfigFormat consulConfigFormat =
+			ConsulConfigFormat.fromString(consulConfigProperties.getConsulConfigFormat());
+		if (consulConfigFormat == ConsulConfigFormat.KEY_VALUE) {
+			parsePropertiesInKeyValueFormat(values);
+		} else if (consulConfigFormat == ConsulConfigFormat.PROPERTIES) {
+			parsePropertiesInPropertiesFormat(values);
+		}
 	}
 
-   /**
-    * Parses the properties in key value style i.e., values are expected to be either a sub key or a
-    * constant
-    *
-    * @param values
-    */
-   private void parsePropertiesInKeyValueFormat(List<GetValue> values) {
-      if (values == null) {
-         return;
-      }
+	/**
+	 * Parses the properties in key value style i.e., values are expected to be either a sub key or a
+	 * constant
+	 *
+	 * @param values
+	 */
+	private void parsePropertiesInKeyValueFormat(List<GetValue> values) {
+		if (values == null) {
+			return;
+		}
 
-      for (GetValue getValue : values) {
-         String key = getValue.getKey();
-         if (!StringUtils.endsWithIgnoreCase(key, "/")) {
-            key = key.replace(context, "").replace('/', '.');
-            String value = getDecoded(getValue.getValue());
-            properties.put(key, value);
-         }
-      }
-   }
+		for (GetValue getValue : values) {
+			String key = getValue.getKey();
+			if (!StringUtils.endsWithIgnoreCase(key, "/")) {
+				key = key.replace(context, "").replace('/', '.');
+				String value = getDecoded(getValue.getValue());
+				properties.put(key, value);
+			}
+		}
+	}
 
-   /**
-    * Parses the properties in key value style i.e., values are expected to be either a sub key or a
-    * constant
-    *
-    * @param values
-    */
-   private void parsePropertiesInPropertiesFormat(List<GetValue> values) {
-      if (values == null) {
-         return;
-      }
+	/**
+	 * Parses the properties in key value style i.e., values are expected to be either a sub key or a
+	 * constant
+	 *
+	 * @param values
+	 */
+	private void parsePropertiesInPropertiesFormat(List<GetValue> values) {
+		if (values == null) {
+			return;
+		}
 
-      for (GetValue getValue : values) {
-         String key = getValue.getKey().replace(context, "");
-         if (!consulConfigProperties.getConsulConfigPropertiesKey().equals(key)) {
-            continue;
-         }
+		for (GetValue getValue : values) {
+			String key = getValue.getKey().replace(context, "");
+			if (!consulConfigProperties.getConsulConfigPropertiesKey().equals(key)) {
+				continue;
+			}
 
-         final String value = getDecoded(getValue.getValue());
-         final Properties props = new Properties();
+			final String value = getDecoded(getValue.getValue());
+			final Properties props = new Properties();
 
-         try {
-            // Must use the ISO-8859-1 encoding because Properties.load(stream) expects it.
-            props.load(new ByteArrayInputStream(value.getBytes("ISO-8859-1")));
+			try {
+				// Must use the ISO-8859-1 encoding because Properties.load(stream) expects it.
+				props.load(new ByteArrayInputStream(value.getBytes("ISO-8859-1")));
 
-            for (String propKey: props.stringPropertyNames()) {
-               properties.put(propKey, props.getProperty(propKey));
-            }
+				for (String propKey: props.stringPropertyNames()) {
+					properties.put(propKey, props.getProperty(propKey));
+				}
 
-         } catch (IOException e) {
-            throw new IllegalArgumentException(value + " can't be encoded using ISO-8859-1");
-         }
-      }
-   }
+			} catch (IOException e) {
+				throw new IllegalArgumentException(value + " can't be encoded using ISO-8859-1");
+			}
+		}
+	}
 
 	public String getDecoded(String value) {
 		if (value == null)

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocator.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocator.java
@@ -77,7 +77,7 @@ public class ConsulPropertySourceLocator implements PropertySourceLocator {
 	}
 
 	private ConsulPropertySource create(String context) {
-		return new ConsulPropertySource(context, consul, properties.getAclToken());
+		return new ConsulPropertySource(context, consul, properties);
 	}
 
 	private void addProfiles(List<String> contexts, String baseContext,


### PR DESCRIPTION

Added the following changes
1. Added support to specify configuration in consul in different formats i.e.,
   configuration as key value pairs, configuration as property file contents

   In configuration as key value pairs format, users are allowed to specify configuration in consul
   using key value pairs where a value is either a constant or is a subkey

   In configuration as property file contents, users are allowed to specify configuration in consul
   with a single key and value as the contents of a properties file. (each line is separted using
   new line and any line starting with # is ignored

2. Made sure the original key value style of specifying configuration works and still is the default.

3. Made sure that Properties style works if config is overridden.