### PR TITLE
Skips docker's interfaces

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/IpAddressUtils.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/IpAddressUtils.java
@@ -51,6 +51,12 @@ public class IpAddressUtils {
 				 enumNic.hasMoreElements(); ) {
 				NetworkInterface ifc = enumNic.nextElement();
 				if (ifc.isUp()) {
+					final String displayName = ifc.getDisplayName();
+
+					if (displayName.matches("docker.*") || displayName.matches("veth.*")) {
+						continue;
+					}
+
 					for (Enumeration<InetAddress> enumAddr = ifc.getInetAddresses();
 						 enumAddr.hasMoreElements(); ) {
 						InetAddress address = enumAddr.nextElement();


### PR DESCRIPTION
The valid IP can be used for communicating w/ docker and w/ the outside, which is probably what you want when developing