### PR TITLE
Allow service that will be defined to have the name customizable

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
@@ -74,6 +74,8 @@ public class ConsulDiscoveryProperties {
 
 	private int catalogServicesWatchTimeout = 2;
 
+	private String service;
+	
 	private String instanceId;
 
 	private String scheme = "http";

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
@@ -177,6 +177,12 @@ public class ConsulLifecycle extends AbstractDiscoveryLifecycle {
 	protected boolean isEnabled() {
 		return this.properties.getLifecycle().isEnabled();
 	}
+	
+	@Override
+	protected String getAppName() {
+		String appName = properties.getService();
+		return StringUtils.isEmpty(appName) ? super.getAppName() : appName;
+	}
 
 	/**
 	 * @return the serviceId of the Management Service

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedServiceNameTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedServiceNameTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.discovery;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Map;
+
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.Response;
+import com.ecwid.consul.v1.agent.model.Service;
+
+/**
+ * @author Spencer Gibb
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@SpringApplicationConfiguration(classes = TestPropsConfig.class)
+@WebIntegrationTest(value = { "spring.application.name=myTestService",
+		"spring.cloud.consul.discovery.instanceId=myTestService1",
+		"spring.cloud.consul.discovery.service=myprefix-${spring.application.name}"}, randomPort = true)
+public class ConsulLifecycleCustomizedServiceNameTests {
+
+	@Autowired
+	ConsulLifecycle lifecycle;
+
+	@Autowired
+	ConsulClient consul;
+
+	@Autowired
+	ApplicationContext context;
+
+	@Test
+	public void contextLoads() {
+		Response<Map<String, Service>> response = consul.getAgentServices();
+		Map<String, Service> services = response.getValue();
+		Service service = services.get("myTestService1");
+		assertNotNull("service was null", service);
+		assertNotEquals("service port is 0", 0, service.getPort().intValue());
+		assertEquals("service id was wrong", "myTestService1", service.getId());
+		assertEquals("service name was wrong", "myprefix-myTestService", service.getService());
+	}
+}


### PR DESCRIPTION
We use ACLs to control what services can be registered based on various business units.  Since the consul registry doesn't support a hierarchy (similar to the KV store) we use a prefix on the service name, but use that prefix in the KV store as part of the hierarchy.

Allowing the service name to be customized allows this functionality to work.