### PR TITLE
Add support for registering using an alternate external port

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
@@ -63,6 +63,8 @@ public class ConsulDiscoveryProperties {
 
 	private String hostname;
 
+	private Integer externalPort;
+
 	private Lifecycle lifecycle = new Lifecycle();
 
 	/**

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
@@ -30,6 +30,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.util.InetUtils;
 
 /**
+ * Defines configuration for service discovery and registration.
+ *
  * @author Spencer Gibb
  */
 @ConfigurationProperties("spring.cloud.consul.discovery")
@@ -45,25 +47,36 @@ public class ConsulDiscoveryProperties {
 
 	private String aclToken;
 
+	/** Tags to use when registering service */
 	private List<String> tags = new ArrayList<>();
 
+	/** Is service discovery enabled? */
 	private boolean enabled = true;
 
+	/** Tags to use when registering management service */
 	private List<String> managementTags = Arrays.asList(MANAGEMENT);
 
+	/** Alternate server path to invoke for health checking */
 	private String healthCheckPath = "/health";
 
+	/** Custom health check url to override default */
 	private String healthCheckUrl;
 
+	/** How often to perform the health check (e.g. 10s) */
 	private String healthCheckInterval = "10s";
 
+	/** Timeout for health check (e.g. 10s) */
 	private String healthCheckTimeout;
 
+	/** IP address to use when accessing service (must also set preferIpAddress
+			to use) */
 	private String ipAddress;
 
+	/** Hostname to use when accessing server */
 	private String hostname;
 
-	private Integer externalPort;
+	/** Port to register the service under (defaults to listening port) */
+	private Integer port;
 
 	private Lifecycle lifecycle = new Lifecycle();
 
@@ -76,10 +89,13 @@ public class ConsulDiscoveryProperties {
 
 	private int catalogServicesWatchTimeout = 2;
 
+	/** Unique service instance id */
 	private String instanceId;
 
+	/** Whether to register an http or https service */
 	private String scheme = "http";
 
+	/** Suffix to use when registering management service */
 	private String managementSuffix = MANAGEMENT;
 
 	private ConsulDiscoveryProperties() {}

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
@@ -78,13 +78,18 @@ public class ConsulLifecycle extends AbstractDiscoveryLifecycle {
 		service.setName(normalizeForDns(appName));
 		service.setTags(createTags());
 
-		Integer port;
-		if (shouldRegisterManagement()) {
-			port = getManagementPort();
-		} else {
-			port = service.getPort();
+		// If an alternate external port is specified, register using it instead
+		if (properties.getExternalPort() != null) {
+			service.setPort(properties.getExternalPort());
 		}
-		service.setCheck(createCheck(port));
+
+		Integer checkPort;
+		if (shouldRegisterManagement()) {
+			checkPort = getManagementPort();
+		} else {
+			checkPort = service.getPort();
+		}
+		service.setCheck(createCheck(checkPort));
 
 		register(service);
 	}

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
@@ -50,7 +50,7 @@ public class ConsulLifecycle extends AbstractDiscoveryLifecycle {
 
 	@Autowired(required = false)
 	private ServletContext servletContext;
-	
+
 	private NewService service = new NewService();
 
 	public ConsulLifecycle(ConsulClient client, ConsulDiscoveryProperties properties, HeartbeatProperties ttlConfig) {
@@ -79,8 +79,8 @@ public class ConsulLifecycle extends AbstractDiscoveryLifecycle {
 		service.setTags(createTags());
 
 		// If an alternate external port is specified, register using it instead
-		if (properties.getExternalPort() != null) {
-			service.setPort(properties.getExternalPort());
+		if (properties.getPort() != null) {
+			service.setPort(properties.getPort());
 		}
 
 		Integer checkPort;

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedPropsTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedPropsTests.java
@@ -47,7 +47,8 @@ import com.ecwid.consul.v1.agent.model.Service;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @SpringApplicationConfiguration(classes = TestPropsConfig.class)
 @WebIntegrationTest(value = { "spring.application.name=myTestService",
-		"spring.cloud.consul.discovery.instanceId=myTestService1" }, randomPort = true)
+		"spring.cloud.consul.discovery.instanceId=myTestService1",
+		"spring.cloud.consul.discovery.externalPort=4452"}, randomPort = true)
 public class ConsulLifecycleCustomizedPropsTests {
 
 	@Autowired
@@ -65,7 +66,7 @@ public class ConsulLifecycleCustomizedPropsTests {
 		Map<String, Service> services = response.getValue();
 		Service service = services.get("myTestService1");
 		assertNotNull("service was null", service);
-		assertNotEquals("service port is 0", 0, service.getPort().intValue());
+		assertEquals("service port is external port", 4452, service.getPort().intValue());
 		assertEquals("service id was wrong", "myTestService1", service.getId());
 		assertEquals("service name was wrong", "myTestService", service.getService());
 	}

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedPropsTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedPropsTests.java
@@ -48,7 +48,7 @@ import com.ecwid.consul.v1.agent.model.Service;
 @SpringApplicationConfiguration(classes = TestPropsConfig.class)
 @WebIntegrationTest(value = { "spring.application.name=myTestService",
 		"spring.cloud.consul.discovery.instanceId=myTestService1",
-		"spring.cloud.consul.discovery.externalPort=4452"}, randomPort = true)
+		"spring.cloud.consul.discovery.port=4452"}, randomPort = true)
 public class ConsulLifecycleCustomizedPropsTests {
 
 	@Autowired
@@ -66,7 +66,7 @@ public class ConsulLifecycleCustomizedPropsTests {
 		Map<String, Service> services = response.getValue();
 		Service service = services.get("myTestService1");
 		assertNotNull("service was null", service);
-		assertEquals("service port is external port", 4452, service.getPort().intValue());
+		assertEquals("service port is discovery port", 4452, service.getPort().intValue());
 		assertEquals("service id was wrong", "myTestService1", service.getId());
 		assertEquals("service name was wrong", "myTestService", service.getService());
 	}


### PR DESCRIPTION
Sometimes the port that clients use to access a service is not the same port that the service is listening on. Maybe you have a web server sitting in front or maybe you're running in a docker container. In either case, one needs the ability to specify this alternate external port.

This PR adds an additional option to ConsulDiscoveryProperties for the external port. If it is provided, it is used when registering the service, otherwise it falls back to status quo behaviour.