### PR TITLE
Allow multiple dataKey so properties can be loaded from multiple keys

### DIFF
--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
@@ -48,7 +48,7 @@ public class ConsulConfigProperties {
 	 * then the following field is used as key to look up consul for configuration.
 	 */
 	@NotEmpty
-	private String dataKey = "data";
+	private String [] dataKey = {"data"};
 
 	private String aclToken;
 

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySource.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySource.java
@@ -32,6 +32,7 @@ import com.ecwid.consul.v1.kv.model.GetValue;
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 import static org.springframework.util.Base64Utils.decodeFromString;
@@ -114,7 +115,7 @@ public class ConsulPropertySource extends EnumerablePropertySource<ConsulClient>
 
 		for (GetValue getValue : values) {
 			String key = getValue.getKey().replace(context, "");
-			if (configProperties.getDataKey().equals(key)) {
+			if (ObjectUtils.containsElement(configProperties.getDataKey(), key)) {
 				final String value = getDecoded(getValue.getValue());
 				final Properties props = generateProperties(value, format);
 

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulPropertySourceTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulPropertySourceTests.java
@@ -81,6 +81,21 @@ public class ConsulPropertySourceTests {
 
 		assertProperties(source, "foopropval", "barpropval");
 	}
+	
+	@Test
+	public void testPropertiesWithMultipleDataKeys() {
+		// properties file property
+		propertiesContext = prefix + "/properties";
+		client.setKVValue(propertiesContext+"/data", "fooprop=foopropval");
+		client.setKVValue(propertiesContext+"/data2", "bar.prop=barpropval");
+
+		ConsulConfigProperties configProperties = new ConsulConfigProperties();
+		configProperties.setFormat(ConsulConfigProperties.Format.PROPERTIES);
+		configProperties.setDataKey(new String[]{"data", "data2"});
+		ConsulPropertySource source = getConsulPropertySource(configProperties, propertiesContext);
+
+		assertProperties(source, "foopropval", "barpropval");
+	}
 
 	@Test
 	public void testYaml() {
@@ -94,7 +109,23 @@ public class ConsulPropertySourceTests {
 
 		assertProperties(source, "fooymlval", "barymlval");
 	}
+	
+	@Test
+	public void testYamlWithMultipleDataKeys() {
+		// yaml file property
+		String yamlContext = prefix + "/yaml";
+		client.setKVValue(yamlContext+"/data", "fooprop: fooymlval");
+		client.setKVValue(yamlContext+"/data2", "bar:\n  prop: barymlval");
 
+		ConsulConfigProperties configProperties = new ConsulConfigProperties();
+		configProperties.setFormat(ConsulConfigProperties.Format.YAML);
+		configProperties.setDataKey(new String[]{"data", "data2"});
+		ConsulPropertySource source = getConsulPropertySource(configProperties, yamlContext);
+
+		assertProperties(source, "fooymlval", "barymlval");
+	}
+	
+	
 	private ConsulPropertySource getConsulPropertySource(ConsulConfigProperties configProperties, String context) {
 		ConsulPropertySource source = new ConsulPropertySource(context, client, configProperties);
 		source.init();


### PR DESCRIPTION
For Property and Yaml formats it would be nice to be able to have multiple keys be used.