### PR TITLE
Refactoring serviceId to serviceName

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
@@ -89,8 +89,8 @@ public class ConsulDiscoveryProperties {
 
 	private int catalogServicesWatchTimeout = 2;
 
-	/** Unique service id */
-	private String serviceId;
+	/** Service name */
+	private String serviceName;
 
 	/** Unique service instance id */
 	private String instanceId;

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
@@ -185,7 +185,7 @@ public class ConsulLifecycle extends AbstractDiscoveryLifecycle {
 	
 	@Override
 	protected String getAppName() {
-		String appName = properties.getServiceId();
+		String appName = properties.getServiceName();
 		return StringUtils.isEmpty(appName) ? super.getAppName() : appName;
 	}
 

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedServiceNameTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedServiceNameTests.java
@@ -44,7 +44,7 @@ import com.ecwid.consul.v1.agent.model.Service;
 @SpringApplicationConfiguration(classes = TestPropsConfig.class)
 @WebIntegrationTest(value = { "spring.application.name=myTestService",
 		"spring.cloud.consul.discovery.instanceId=myTestService1",
-		"spring.cloud.consul.discovery.serviceId=myprefix-${spring.application.name}"}, randomPort = true)
+		"spring.cloud.consul.discovery.serviceName=myprefix-${spring.application.name}"}, randomPort = true)
 public class ConsulLifecycleCustomizedServiceNameTests {
 
 	@Autowired


### PR DESCRIPTION
The field `serviceId` should really be called `serviceName` to match the consul nomenclature as `instanceId` is really the unique serviceId.