### PR TITLE
Added support for customizing address for service

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
@@ -25,8 +25,8 @@ import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.extern.apachecommons.CommonsLog;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.util.InetUtils;
@@ -38,7 +38,7 @@ import org.springframework.cloud.util.InetUtils;
  */
 @ConfigurationProperties("spring.cloud.consul.discovery")
 @Data
-@CommonsLog
+@NoArgsConstructor(access=AccessLevel.PRIVATE)
 public class ConsulDiscoveryProperties {
 
 	protected static final String MANAGEMENT = "management";
@@ -86,7 +86,12 @@ public class ConsulDiscoveryProperties {
 	 * Use ip address rather than hostname during registration
 	 */
 	private boolean preferIpAddress = false;
-
+	
+	/**
+	 * Source of how we will determine the address to use
+	 */
+	private boolean preferAgentAddress = false;
+	
 	private int catalogServicesWatchDelay = 10;
 
 	private int catalogServicesWatchTimeout = 2;
@@ -108,8 +113,6 @@ public class ConsulDiscoveryProperties {
 	 * This allows filtering services by a single tag.
 	 */
 	private Map<String, String> serverListQueryTags = new HashMap<>();
-
-	private ConsulDiscoveryProperties() {}
 
 	public ConsulDiscoveryProperties(InetUtils inetUtils) {
 		this.hostInfo = inetUtils.findFirstNonLoopbackHostInfo();

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
@@ -81,7 +81,9 @@ public class ConsulLifecycle extends AbstractDiscoveryLifecycle {
 		Assert.notNull(service.getPort(), "service.port has not been set");
 		String appName = getAppName();
 		service.setId(getServiceId());
-		service.setAddress(properties.getHostname());
+		if(!properties.isPreferAgentAddress()) {
+			service.setAddress(properties.getHostname());
+		}
 		service.setName(normalizeForDns(appName));
 		service.setTags(createTags());
 

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedAgentAddressTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedAgentAddressTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.discovery;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.util.StringUtils;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.Response;
+import com.ecwid.consul.v1.agent.model.Service;
+
+/**
+ * @author Spencer Gibb
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@SpringApplicationConfiguration(classes = TestPropsConfig.class)
+@WebIntegrationTest(value = { "spring.application.name=myTestService",
+		"spring.cloud.consul.discovery.instanceId=myTestService1",
+		"spring.cloud.consul.discovery.serviceName=myprefix-${spring.application.name}",
+		"spring.cloud.consul.discovery.preferAgentAddress=true"}, randomPort = true)
+public class ConsulLifecycleCustomizedAgentAddressTests {
+
+	@Autowired
+	ConsulLifecycle lifecycle;
+
+	@Autowired
+	ConsulClient consul;
+	
+	@Autowired
+	ConsulDiscoveryProperties discoveryProperties;
+
+	@Autowired
+	ApplicationContext context;
+
+	@Test
+	public void contextLoads() {
+		Response<Map<String, Service>> response = consul.getAgentServices();
+		Map<String, Service> services = response.getValue();
+		Service service = services.get("myTestService1");
+		assertNotNull("service was null", service);
+		assertNotEquals("service port is 0", 0, service.getPort().intValue());
+		assertEquals("service id was wrong", "myTestService1", service.getId());
+		assertEquals("service name was wrong", "myprefix-myTestService", service.getService());
+		assertTrue("service address must be empty", StringUtils.isEmpty(service.getAddress()));
+	}
+}


### PR DESCRIPTION
We are seeing an issue in which the wrong IP address is used when a machine has multiple ethernet adapters.

For instance we have the Consul Agent binding to eth0 on a particular machine, but when the service gets registered it is using the IP address from eth1 instead which causes problems as that isn't routable for the service.

Generally the address shouldn't be required as this isn't needed by Consul Service Definition by default.  If the address isn't provided then the agent's address will be used instead (this generally helps in the docker world as well).

The default behavior is set to now omit the address and use the agents IP, we can change this if desired by I think might be the most ideal approach in these situations and should work for almost all other.  The option for Lookup allow the existing behavior.

I didn't add to this pull request, as it might not be needed, but further enhancement might be added to get a named adapter instead of just find non-loopback found.

We might also want to pull some of this support down further into health checks as they can also be affected by the presence of multiple adapters.  I may add that to another pull request later on.