### PR TITLE
Travis for forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,9 @@ script:
 - if [ "${TRAVIS_REPO_SLUG}" == "spring-cloud/spring-cloud-consul" ]; then
     '[ "${TRAVIS_PULL_REQUEST}" != "false" ] || ./mvnw --settings .settings.xml deploy -nsu -Dmaven.test.redirectTestOutputToFile=true';
     '[ "${TRAVIS_PULL_REQUEST}" = "false" ]  || ./mvnw --settings .settings.xml install -nsu -Dmaven.test.redirectTestOutputToFile=true';
+  else
+    ./mvnw --settings .settings.xml test -nsu -Dmaven.test.redirectTestOutputToFile=true
   fi
-- ./mvnw --settings .settings.xml test -nsu -Dmaven.test.redirectTestOutputToFile=true
 env:
   global:
   - GIT_NAME="Spencer Gibb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 - ./docs/src/main/asciidoc/ghpages.sh
 script:
 - ./src/test/bash/travis_run_consul.sh
-- if [ "${TRAVIS_REPO_SLUG} == "spring-cloud/spring-cloud-consul" ]; then
+- if [ "${TRAVIS_REPO_SLUG}" == "spring-cloud/spring-cloud-consul" ]; then
     '[ "${TRAVIS_PULL_REQUEST}" != "false" ] || ./mvnw --settings .settings.xml deploy -nsu -Dmaven.test.redirectTestOutputToFile=true';
     '[ "${TRAVIS_PULL_REQUEST}" = "false" ]  || ./mvnw --settings .settings.xml install -nsu -Dmaven.test.redirectTestOutputToFile=true';
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
     '[ "${TRAVIS_PULL_REQUEST}" != "false" ] || ./mvnw --settings .settings.xml deploy -nsu -Dmaven.test.redirectTestOutputToFile=true';
     '[ "${TRAVIS_PULL_REQUEST}" = "false" ]  || ./mvnw --settings .settings.xml install -nsu -Dmaven.test.redirectTestOutputToFile=true';
   else
-    ./mvnw --settings .settings.xml test -nsu -Dmaven.test.redirectTestOutputToFile=true
+    ./mvnw --settings .settings.xml test -nsu -Dmaven.test.redirectTestOutputToFile=true;
   fi
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,11 @@ install:
 - ./docs/src/main/asciidoc/ghpages.sh
 script:
 - ./src/test/bash/travis_run_consul.sh
-- '[ "${TRAVIS_PULL_REQUEST}" != "false" ] || ./mvnw --settings .settings.xml deploy -nsu -Dmaven.test.redirectTestOutputToFile=true'
-- '[ "${TRAVIS_PULL_REQUEST}" = "false" ]  || ./mvnw --settings .settings.xml install -nsu -Dmaven.test.redirectTestOutputToFile=true'
+- if [ "${TRAVIS_REPO_SLUG} == "spring-cloud/spring-cloud-consul" ]; then
+    '[ "${TRAVIS_PULL_REQUEST}" != "false" ] || ./mvnw --settings .settings.xml deploy -nsu -Dmaven.test.redirectTestOutputToFile=true';
+    '[ "${TRAVIS_PULL_REQUEST}" = "false" ]  || ./mvnw --settings .settings.xml install -nsu -Dmaven.test.redirectTestOutputToFile=true';
+  fi
+- ./mvnw --settings .settings.xml test -nsu -Dmaven.test.redirectTestOutputToFile=true
 env:
   global:
   - GIT_NAME="Spencer Gibb"


### PR DESCRIPTION
Sometimes it's helpful for forked repos to verify build functionality with travis prior to submitting pull requests.
This modification should leave the build functionality unaltered when preformed by the upstream repo (spring-cloud/spring-cloud-consul), but limit forked repos to just running tests (and skip deploy/install tasks).
Also, without this change forked repositories will fail with travis because they don't have permissions to complete the deploy task.