### PR TITLE
Make ConfigWatch conditionable based on consul server connection

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -13,7 +13,7 @@
 	<packaging>pom</packaging>
 	<name>Spring Cloud Consul Docs</name>
 	<description>Spring Cloud Docs</description>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0.M6-v2</version>
 	<properties>
 		<docs.main>spring-cloud-consul</docs.main>
 		<main.basedir>${basedir}/..</main.basedir>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -13,7 +13,7 @@
 	<packaging>pom</packaging>
 	<name>Spring Cloud Consul Docs</name>
 	<description>Spring Cloud Docs</description>
-	<version>1.0.0.M6-v2</version>
+	<version>1.0.0.M6-v3</version>
 	<properties>
 		<docs.main>spring-cloud-consul</docs.main>
 		<main.basedir>${basedir}/..</main.basedir>

--- a/maven-release.sh
+++ b/maven-release.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eo pipefail
+#OLD_VERSION=1.0.0.BUILD-SNAPSHOT
+#NEW_VERSION=1.0.0.M6-v2
+OLD_VERSION=$(sed -n '/<version>/ {s/\s*<.\?version>//gp;q;}' pom.xml )
+NEW_VERSION=${OLD_VERSION%%-*}-v$((${OLD_VERSION##*-v}  + 1))
+
+grep -rl "$OLD_VERSION" --include=pom.xml|xargs -n1 sed -i "s/$OLD_VERSION/$NEW_VERSION/g"
+mvn deploy -Dmaven.test.skip=true -DaltDeploymentRepository=aws-release::default::file://$PWD/maven-repo
+cd maven-repo
+aws s3 cp --region eu-west-1  --acl=public-read  --recursive org s3://maven.sequenceiq.com/releases/org/

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.cloud</groupId>
 	<artifactId>spring-cloud-consul</artifactId>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0.M6-v2</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud Consul</name>
 	<description>Spring Cloud Consul</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.cloud</groupId>
 	<artifactId>spring-cloud-consul</artifactId>
-	<version>1.0.0.M6-v2</version>
+	<version>1.0.0.M6-v3</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud Consul</name>
 	<description>Spring Cloud Consul</description>

--- a/spring-cloud-consul-bus/pom.xml
+++ b/spring-cloud-consul-bus/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.M6-v2</version>
+		<version>1.0.0.M6-v3</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-consul-bus/pom.xml
+++ b/spring-cloud-consul-bus/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.BUILD-SNAPSHOT</version>
+		<version>1.0.0.M6-v2</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-consul-config/pom.xml
+++ b/spring-cloud-consul-config/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.M6-v2</version>
+		<version>1.0.0.M6-v3</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-consul-config/pom.xml
+++ b/spring-cloud-consul-config/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.BUILD-SNAPSHOT</version>
+		<version>1.0.0.M6-v2</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigAutoConfiguration.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigAutoConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.endpoint.RefreshEndpoint;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -35,6 +36,7 @@ public class ConsulConfigAutoConfiguration {
 	protected static class ConsulRefreshConfiguration {
 		@Bean
 		@ConditionalOnProperty(name = "spring.cloud.consul.config.watch.enabled", matchIfMissing = true)
+		@Conditional(ConsulConnectionChecker.class)
 		public ConfigWatch configWatch(ConsulPropertySourceLocator locator,
 										   ConsulClient consul) {
 			return new ConfigWatch(locator.getContexts(), consul);

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
@@ -59,7 +59,7 @@ public class ConsulConfigProperties {
 	/**
 	 * Throw exceptions during config lookup if true, otherwise, log warnings.
 	 */
-	private boolean failFast = true;
+	private boolean failFast = false;
 
 	@Data
 	public class Watch {

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConnectionChecker.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConnectionChecker.java
@@ -1,0 +1,34 @@
+package org.springframework.cloud.consul.config;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+
+public class ConsulConnectionChecker implements Condition {
+
+    @Override
+    public boolean matches(ConditionContext conditionContext, AnnotatedTypeMetadata annotatedTypeMetadata) {
+
+        Environment environment = conditionContext.getEnvironment();
+        String host = environment.getProperty("spring.cloud.consul.host");
+        String port = environment.getProperty("spring.cloud.consul.port");
+        try {
+            URL url = new URL("http://" + host + ":" + port);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            connection.connect();
+            int code = connection.getResponseCode();
+
+            return code == 200;
+        } catch (Exception e) {
+
+            return false;
+        }
+
+    }
+}

--- a/spring-cloud-consul-core/pom.xml
+++ b/spring-cloud-consul-core/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.M6-v2</version>
+		<version>1.0.0.M6-v3</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-consul-core/pom.xml
+++ b/spring-cloud-consul-core/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.BUILD-SNAPSHOT</version>
+		<version>1.0.0.M6-v2</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-consul-dependencies/pom.xml
+++ b/spring-cloud-consul-dependencies/pom.xml
@@ -9,7 +9,7 @@
         <relativePath/>
 	</parent>
 	<artifactId>spring-cloud-consul-dependencies</artifactId>
-	<version>1.0.0.M6-v2</version>
+	<version>1.0.0.M6-v3</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-consul-dependencies</name>
 	<description>Spring Cloud Consul Dependencies</description>

--- a/spring-cloud-consul-dependencies/pom.xml
+++ b/spring-cloud-consul-dependencies/pom.xml
@@ -9,7 +9,7 @@
         <relativePath/>
 	</parent>
 	<artifactId>spring-cloud-consul-dependencies</artifactId>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0.M6-v2</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-consul-dependencies</name>
 	<description>Spring Cloud Consul Dependencies</description>

--- a/spring-cloud-consul-discovery/pom.xml
+++ b/spring-cloud-consul-discovery/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.M6-v2</version>
+		<version>1.0.0.M6-v3</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-consul-discovery/pom.xml
+++ b/spring-cloud-consul-discovery/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.BUILD-SNAPSHOT</version>
+		<version>1.0.0.M6-v2</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-consul-sample/pom.xml
+++ b/spring-cloud-consul-sample/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.M6-v2</version>
+		<version>1.0.0.M6-v3</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-consul-sample/pom.xml
+++ b/spring-cloud-consul-sample/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.BUILD-SNAPSHOT</version>
+		<version>1.0.0.M6-v2</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/spring-cloud-starter-consul-all/pom.xml
+++ b/spring-cloud-starter-consul-all/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.BUILD-SNAPSHOT</version>
+		<version>1.0.0.M6-v2</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-starter-consul-all</artifactId>

--- a/spring-cloud-starter-consul-all/pom.xml
+++ b/spring-cloud-starter-consul-all/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.M6-v2</version>
+		<version>1.0.0.M6-v3</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-starter-consul-all</artifactId>

--- a/spring-cloud-starter-consul-bus/pom.xml
+++ b/spring-cloud-starter-consul-bus/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.M6-v2</version>
+		<version>1.0.0.M6-v3</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-starter-consul-bus</artifactId>

--- a/spring-cloud-starter-consul-bus/pom.xml
+++ b/spring-cloud-starter-consul-bus/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.BUILD-SNAPSHOT</version>
+		<version>1.0.0.M6-v2</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-starter-consul-bus</artifactId>

--- a/spring-cloud-starter-consul-config/pom.xml
+++ b/spring-cloud-starter-consul-config/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.BUILD-SNAPSHOT</version>
+		<version>1.0.0.M6-v2</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-starter-consul-config</artifactId>

--- a/spring-cloud-starter-consul-config/pom.xml
+++ b/spring-cloud-starter-consul-config/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.M6-v2</version>
+		<version>1.0.0.M6-v3</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-starter-consul-config</artifactId>

--- a/spring-cloud-starter-consul-discovery/pom.xml
+++ b/spring-cloud-starter-consul-discovery/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.M6-v2</version>
+		<version>1.0.0.M6-v3</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-starter-consul-discovery</artifactId>

--- a/spring-cloud-starter-consul-discovery/pom.xml
+++ b/spring-cloud-starter-consul-discovery/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.BUILD-SNAPSHOT</version>
+		<version>1.0.0.M6-v2</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-starter-consul-discovery</artifactId>

--- a/spring-cloud-starter-consul/pom.xml
+++ b/spring-cloud-starter-consul/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.M6-v2</version>
+		<version>1.0.0.M6-v3</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-starter-consul</artifactId>

--- a/spring-cloud-starter-consul/pom.xml
+++ b/spring-cloud-starter-consul/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-consul</artifactId>
-		<version>1.0.0.BUILD-SNAPSHOT</version>
+		<version>1.0.0.M6-v2</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-starter-consul</artifactId>


### PR DESCRIPTION
Completes 2212b9e31a6922c4e913531520fff588dca9c4cf to fix #137

`failFast=false` will save ConsulPropertySourceLocator from fsiling, but ConfigWatch will be started, and throwing an exception at each try:

```
2016-02-26 13:22:30.459 ERROR 27243 --- [pool-1-thread-1] o.s.cloud.consul.config.ConfigWatch      : Error initializing listener for context config/null/

com.ecwid.consul.transport.TransportException: java.net.ConnectException: Connection refused
        at com.ecwid.consul.transport.AbstractHttpTransport.executeRequest(AbstractHttpTransport.java:80) ~[consul-api-1.1.8.jar!/:na]
        at com.ecwid.consul.transport.AbstractHttpTransport.makeGetRequest(AbstractHttpTransport.java:39) ~[consul-api-1.1.8.jar!/:na]
        at com.ecwid.consul.v1.ConsulRawClient.makeGetRequest(ConsulRawClient.java:81) ~[consul-api-1.1.8.jar!/:na]
        at com.ecwid.consul.v1.kv.KeyValueConsulClient.getKVValues(KeyValueConsulClient.java:150) ~[consul-api-1.1.8.jar!/:na]
        at com.ecwid.consul.v1.kv.KeyValueConsulClient.getKVValues(KeyValueConsulClient.java:143) ~[consul-api-1.1.8.jar!/:na]
        at com.ecwid.consul.v1.ConsulClient.getKVValues(ConsulClient.java:394) ~[consul-api-1.1.8.jar!/:na]
        at org.springframework.cloud.consul.config.ConfigWatch.watchConfigKeyValues(ConfigWatch.java:78) ~[spring-cloud-consul-config-1.0.0.BUILD-SNAPSHOT.jar!/:1.0.0.BUILD-SNA
PSHOT]

```

