### PR TITLE
Add ConsulServiceDiscoveryFilter support

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.consul.discovery;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +59,12 @@ public class ConsulDiscoveryProperties {
 	/** Tags to use when registering management service */
 	private List<String> managementTags = Arrays.asList(MANAGEMENT);
 
+	/** Tags for services that should be excluded from discovery.  Default is empty */
+	private List<String> excludedTags = Collections.emptyList();
+
+	/** Tags for services that should be included in discovery.  Default is null, indicating all services */
+	private List<String> includedTags = null;
+
 	/** Alternate server path to invoke for health checking */
 	private String healthCheckPath = "/health";
 
@@ -86,12 +93,12 @@ public class ConsulDiscoveryProperties {
 	 * Use ip address rather than hostname during registration
 	 */
 	private boolean preferIpAddress = false;
-	
+
 	/**
 	 * Source of how we will determine the address to use
 	 */
 	private boolean preferAgentAddress = false;
-	
+
 	private int catalogServicesWatchDelay = 10;
 
 	private int catalogServicesWatchTimeout = 2;
@@ -133,7 +140,7 @@ public class ConsulDiscoveryProperties {
 	@SuppressWarnings("unused")
 	private ConsulDiscoveryProperties() {}
 
-	public ConsulDiscoveryProperties(InetUtils inetUtils) {
+	public ConsulDiscoveryProperties(final InetUtils inetUtils) {
 		this.hostInfo = inetUtils.findFirstNonLoopbackHostInfo();
 		this.ipAddress = this.hostInfo.getIpAddress();
 		this.hostname = this.hostInfo.getHostname();
@@ -143,12 +150,12 @@ public class ConsulDiscoveryProperties {
 		return this.preferIpAddress ? this.ipAddress : this.hostname;
 	}
 
-	public void setHostname(String hostname) {
+	public void setHostname(final String hostname) {
 		this.hostname = hostname;
 		this.hostInfo.override = true;
 	}
 
-	public void setIpAddress(String ipAddress) {
+	public void setIpAddress(final String ipAddress) {
 		this.ipAddress = ipAddress;
 		this.hostInfo.override = true;
 	}

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServiceInstance.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServiceInstance.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.consul.discovery;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.cloud.client.DefaultServiceInstance;
+
+/**
+ * Represents a consul service, including its tags.
+ *
+ * @author Adam Hawthorne
+ */
+public class ConsulServiceInstance extends DefaultServiceInstance {
+
+    private final List<String> tags;
+
+    public ConsulServiceInstance(final String serviceId, final String host,
+            final int port, final boolean secure, final List<String> tags) {
+        super(serviceId, host, port, secure);
+        this.tags = new ArrayList<>(tags);
+    }
+
+    public List<String> getTags() {
+        return new ArrayList<>(tags);
+    }
+
+}

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/filters/AcceptAllDiscoveryFilter.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/filters/AcceptAllDiscoveryFilter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.discovery.filters;
+
+import org.springframework.cloud.consul.discovery.ConsulServiceInstance;
+
+/**
+ * Default {@link ConsulServiceDiscoveryFilter} that accepts all services.
+ */
+public class AcceptAllDiscoveryFilter implements ConsulServiceDiscoveryFilter {
+
+    @Override
+    public boolean accept(final ConsulServiceInstance instance) {
+        return true;
+    }
+
+}

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/filters/ConsulServiceDiscoveryFilter.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/filters/ConsulServiceDiscoveryFilter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.consul.discovery.filters;
+
+import org.springframework.cloud.consul.discovery.ConsulDiscoveryClient;
+import org.springframework.cloud.consul.discovery.ConsulServiceInstance;
+
+/**
+ * Interface for filtering services discovered by {@link ConsulDiscoveryClient}.
+ *
+ * @author Adam Hawthorne
+ */
+public interface ConsulServiceDiscoveryFilter {
+
+	/**
+	 * @param instance the instance potentially being filtered
+	 * @return {@code true} if the {@link ConsulServiceInstance} should be added to the list of services
+	 * discovered by the {@link ConsulDiscoveryClient}, {@code false} if it should not.
+	 */
+    boolean accept(ConsulServiceInstance instance);
+
+}

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/filters/TagMatchingDiscoveryFilter.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/filters/TagMatchingDiscoveryFilter.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.discovery.filters;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.cloud.consul.discovery.ConsulServiceInstance;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
+
+/**
+ * This class filters services based on the existence of certain tags. If a service has
+ * any tag that matches the set of excludeded tags, the service will be rejected by this
+ * filter. If a service has no excluded tags and has a tag that matches the set of
+ * included tags, the service will be accepted by this filter. the
+ * {@linkplain #TagMatchingDiscoveryFilter(Set) one-argument constructor} of this class
+ * includes all tags by default. To only include services with a certain tag, use the
+ * {@linkplain #TagMatchingDiscoveryFilter(Set, Set) two argument constructor} with an
+ * empty {@link Set} for the {@code excludeTagSet} parameter.
+ *
+ * @author Adam Hawthorne
+ */
+public class TagMatchingDiscoveryFilter implements ConsulServiceDiscoveryFilter {
+
+	/** Default includeTagSet */
+	public static final TagSet MATCH_ALL = new TagSet() {
+		@Override
+		public boolean contains(final String tag) {
+			return true;
+		}
+	};
+
+	/** Default excludeTagSet */
+	public static final TagSet MATCH_NONE = new TagSet() {
+		@Override
+		public boolean contains(final String tag) {
+			return false;
+		}
+	};
+
+	private final TagSet excludeTagSet;
+	private final TagSet includeTagSet;
+
+	/**
+	 * Constructor that will accept all services. Using this constructor indicates that no
+	 * services should be filtered.
+	 */
+	public TagMatchingDiscoveryFilter() {
+		this(MATCH_NONE, MATCH_ALL);
+	}
+
+	/**
+	 * Constructor specifying only excluded tags. Using this constructor indicates the
+	 * filter should include all tags.
+	 *
+	 * @param excludeTagSet {@link Set} of tags of services to reject from the filter. The
+	 * argument is copied.
+	 */
+	public TagMatchingDiscoveryFilter(final Set<String> excludeTagSet) {
+		this(copySet(excludeTagSet));
+	}
+
+	/**
+	 * Constructor specifying only excluded tags. Using this constructor indicates the
+	 * filter should include all tags.
+	 *
+	 * @param excludeTagSet {@link TagSet} of tags of services to reject from the filter.
+	 * The argument is NOT copied.
+	 */
+	public TagMatchingDiscoveryFilter(final TagSet excludeTagSet) {
+		this(excludeTagSet, MATCH_ALL);
+	}
+
+	/**
+	 * Constructor specifying excluded and included tags. Excluded tags are applied to the
+	 * entire list of tags first, then the included tags, if the service was not excluded.
+	 *
+	 * @param excludeTagSet {@link Set} of tags of services to reject from the filter. The
+	 * argument is copied.
+	 * @param includeTagSet {@link Set} of tags of services to accept from the filter (if
+	 * not previously rejected by the {{@code excludeTagSet}. The argument is copied.
+	 */
+	public TagMatchingDiscoveryFilter(final Set<String> excludeTagSet,
+			final Set<String> includeTagSet) {
+		this(copySet(excludeTagSet), copySet(includeTagSet));
+	}
+
+	/**
+	 * Constructor specifying excluded and included tags. Excluded tags are applied to the
+	 * entire list of tags first, then the included tags, if the service was not excluded.
+	 *
+	 * @param excludeTagSet {@link Set} of tags of services to reject from the filter. The
+	 * argument is NOT copied.
+	 * @param includeTagSet {@link Set} of tags of services to accept from the filter (if
+	 * not previously rejected by the {{@code excludeTagSet}. The argument is NOT copied.
+	 */
+	public TagMatchingDiscoveryFilter(final TagSet excludeTagSet,
+			final TagSet includeTagSet) {
+		this.excludeTagSet = Preconditions.checkNotNull(excludeTagSet, "excludeTagSet");
+		this.includeTagSet = Preconditions.checkNotNull(includeTagSet, "includeTagSet");
+	}
+
+	/**
+	 * @param instance The {@link ConsulServiceInstance} being tested.
+	 * @return {@code true} if {@code instance.getTags()} contains no excluded tags and
+	 * contains at least one included tag, {@code false} otherwise.
+	 */
+	@Override
+	public boolean accept(final ConsulServiceInstance instance) {
+		boolean result = false;
+		// Always include the empty tag. This will ensure that the MATCH_ALL Set matches
+		// a service with no tags.
+		for (String tag : Iterables.concat(Arrays.asList(""), instance.getTags())) {
+			if (isExcluded(tag)) {
+				return false;
+			}
+			if (isIncluded(tag)) {
+				result = true;
+			}
+		}
+		return result;
+	}
+
+	/**
+	 *
+	 * @param tag the tested tag
+	 * @return {@code true} if the tag is in the exclude set, {@code false} otherwise.
+	 */
+	public boolean isExcluded(final String tag) {
+		return excludeTagSet.contains(tag);
+	}
+
+	/**
+	 * @param tag the tested tag
+	 * @return {@code true} if the tag is in the includeSet, {@code false} otherwise.
+	 */
+	public boolean isIncluded(final String tag) {
+		return includeTagSet.contains(tag);
+	}
+
+	/**
+	 * Convenience method to produce a {@link TagSet} from a {@link Set}.
+	 *
+	 * @param set the {@link Set} to wrap.
+	 *
+	 * @return a {@link TagSet} that wraps the provided set. Changes to the argument will
+	 * be reflected in the return value.
+	 */
+	public static TagSet wrapSet(final Set<String> set) {
+		return new WrappedSetTagSet(set);
+	}
+
+	/**
+	 * Convenience method to produce a {@link TagSet} from a {@link Set}.
+	 *
+	 * @param set the {@link Set} to copy.
+	 *
+	 * @return a {@link TagSet} that copies the provided set. Changes to the argument will
+	 * NOT be reflected in the return value.
+	 */
+	public static TagSet copySet(final Set<String> set) {
+		return wrapSet(new HashSet<>(set));
+	}
+
+	/**
+	 * This class exists to provide a slimmed down interface to a Set. The only required
+	 * operation by this class is set membership. Defensive convenience methods are
+	 * provided to interact with {@link Set}.
+	 */
+	public static interface TagSet {
+		public boolean contains(String tag);
+	}
+
+	private static class WrappedSetTagSet implements TagSet {
+		private final Set<String> wrappedSet;
+
+		WrappedSetTagSet(final Set<String> wrappedSet) {
+			this.wrappedSet = Preconditions.checkNotNull(wrappedSet, "wrappedSet");
+		}
+
+		/**
+		 * @param tag tag being tested for membership
+		 *
+		 * @return {@code true} if the set contains the tag, {@code false} otherwise.
+		 */
+		@Override
+		public boolean contains(final String tag) {
+			return wrappedSet.contains(tag);
+		}
+	}
+}

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/filters/TagMatchingDiscoveryFilterTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/filters/TagMatchingDiscoveryFilterTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2016 by Amobee, Inc.
+ * All Rights Reserved.
+ */
+package org.springframework.cloud.consul.discovery.filters;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.Test;
+import org.springframework.cloud.consul.discovery.ConsulServiceInstance;
+import org.springframework.cloud.consul.discovery.filters.TagMatchingDiscoveryFilter.TagSet;
+
+import com.google.common.collect.Sets;
+
+/**
+ *
+ */
+public class TagMatchingDiscoveryFilterTests {
+
+	@Test
+	public void testExcludeTags() {
+		TagMatchingDiscoveryFilter filter = new TagMatchingDiscoveryFilter(
+				Sets.newHashSet("exclude1", "exclude2"));
+		assertTrue(filter.accept(buildInstance()));
+		assertTrue(filter.accept(buildInstance("unmatched")));
+		assertFalse(filter.accept(buildInstance("exclude1")));
+		assertFalse(filter.accept(buildInstance("unmatched", "exclude2")));
+	}
+
+	@Test
+	public void testIncludeTags() {
+		Set<String> EMPTY_SET = Collections.emptySet();
+		TagMatchingDiscoveryFilter filter = new TagMatchingDiscoveryFilter(EMPTY_SET,
+				Sets.newHashSet("include1", "include2"));
+		assertFalse(filter.accept(buildInstance()));
+		assertFalse(filter.accept(buildInstance("unmatched")));
+		assertTrue(filter.accept(buildInstance("include1")));
+		assertTrue(filter.accept(buildInstance("unmatched", "include2")));
+	}
+
+	@Test
+	public void testExcludeIncludeTags() {
+		TagMatchingDiscoveryFilter filter = new TagMatchingDiscoveryFilter(
+				Sets.newHashSet("exclude1", "exclude2"), Sets.newHashSet("include1", "include2"));
+		assertFalse(filter.accept(buildInstance()));
+		assertFalse(filter.accept(buildInstance("unmatched")));
+		assertTrue(filter.accept(buildInstance("include1")));
+		assertTrue(filter.accept(buildInstance("unmatched", "include1")));
+		assertFalse(filter.accept(buildInstance("exclude1", "include2")));
+	}
+
+	@Test
+	public void testWrappedSet() {
+		Set<String> wrapped = Sets.newHashSet("a", "b");
+		TagSet wrapping = TagMatchingDiscoveryFilter.wrapSet(wrapped);
+		assertTrue(wrapping.contains("a"));
+		assertTrue(wrapping.contains("b"));
+		assertFalse(wrapping.contains("c"));
+
+		wrapped.add("c");
+
+		assertTrue(wrapping.contains("c"));
+	}
+
+	@Test
+	public void testCopiedSet() {
+		Set<String> copied = Sets.newHashSet("a", "b");
+		TagSet copying = TagMatchingDiscoveryFilter.copySet(copied);
+		assertTrue(copying.contains("a"));
+		assertTrue(copying.contains("b"));
+		assertFalse(copying.contains("c"));
+
+		copied.add("c");
+
+		assertFalse(copying.contains("c"));
+	}
+
+	@Test
+	public void testSetConstructor() {
+		Set<String> excludes = Sets.newHashSet("a");
+		TagMatchingDiscoveryFilter filter = new TagMatchingDiscoveryFilter(excludes);
+		assertTrue(filter.isExcluded("a"));
+		assertFalse(filter.isExcluded("b"));
+
+		excludes.add("b");
+		assertFalse(filter.isExcluded("b"));
+	}
+
+	@Test
+	public void testSetSetConstructor() {
+		Set<String> excludes = Sets.newHashSet("a");
+		Set<String> includes = Sets.newHashSet("x");
+		TagMatchingDiscoveryFilter filter = new TagMatchingDiscoveryFilter(excludes, includes);
+		assertTrue(filter.isExcluded("a"));
+		assertFalse(filter.isExcluded("b"));
+
+		excludes.add("b");
+		assertFalse(filter.isExcluded("b"));
+
+		assertTrue(filter.isIncluded("x"));
+		assertFalse(filter.isIncluded("y"));
+
+		includes.add("y");
+		assertFalse(filter.isIncluded("y"));
+	}
+
+	@Test
+	public void testDefaultConstructor() {
+		TagMatchingDiscoveryFilter filter = new TagMatchingDiscoveryFilter();
+		assertFalse(filter.isExcluded("a"));
+		assertTrue(filter.isIncluded("a"));
+	}
+
+
+	private ConsulServiceInstance buildInstance(final String... tags) {
+		return new ConsulServiceInstance("a", "127.0.0.1", 80, true, Arrays.asList(tags));
+	}
+
+}

--- a/spring-cloud-consul-discovery/src/test/resources/consulDiscoveryClientCustomizedTests.properties
+++ b/spring-cloud-consul-discovery/src/test/resources/consulDiscoveryClientCustomizedTests.properties
@@ -1,0 +1,1 @@
+spring.cloud.consul.discovery.excludedTags=excluded,excluded1


### PR DESCRIPTION
- Add ConsulServiceDiscoveryFilter to filter services upon discovery
- Apply filter to ConsulDiscoveryClient while listing services
- Add two implementations: an AcceptAllDiscoveryFilter and a
  TagMatchingDiscoveryFilter
- Add configuration properties for the TagMatchingDiscoveryFilter's
  includes and excludes

Fixes gh-154