### PR TITLE
Add the ability to pass query parameters for service discovery

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClient.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClient.java
@@ -40,6 +40,7 @@ import static org.springframework.cloud.consul.discovery.ConsulServerUtils.findH
 
 /**
  * @author Spencer Gibb
+ * @author Joe Athman
  */
 @CommonsLog
 public class ConsulDiscoveryClient implements DiscoveryClient {
@@ -106,16 +107,20 @@ public class ConsulDiscoveryClient implements DiscoveryClient {
 
 	@Override
 	public List<ServiceInstance> getInstances(final String serviceId) {
+		return getInstances(serviceId, QueryParams.DEFAULT);
+	}
+
+	public List<ServiceInstance> getInstances(final String serviceId, final QueryParams queryParams) {
 		List<ServiceInstance> instances = new ArrayList<>();
 
-		addInstancesToList(instances, serviceId);
+		addInstancesToList(instances, serviceId, queryParams);
 
 		return instances;
 	}
 
-	private void addInstancesToList(List<ServiceInstance> instances, String serviceId) {
+	private void addInstancesToList(List<ServiceInstance> instances, String serviceId, QueryParams queryParams) {
 		Response<List<HealthService>> services = client.getHealthServices(serviceId,
-				this.properties.isQueryPassing(), QueryParams.DEFAULT);
+				this.properties.isQueryPassing(), queryParams);
 		for (HealthService service : services.getValue()) {
 			String host = findHost(service);
 			instances.add(new DefaultServiceInstance(serviceId, host, service
@@ -129,7 +134,7 @@ public class ConsulDiscoveryClient implements DiscoveryClient {
 		Response<Map<String, List<String>>> services = client
 				.getCatalogServices(QueryParams.DEFAULT);
 		for (String serviceId : services.getValue().keySet()) {
-			addInstancesToList(instances, serviceId);
+			addInstancesToList(instances, serviceId, QueryParams.DEFAULT);
 		}
 		return instances;
 	}

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClientTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClientTests.java
@@ -20,6 +20,9 @@ import static org.junit.Assert.*;
 
 import java.util.List;
 
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.QueryParams;
+import com.ecwid.consul.v1.Response;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,6 +38,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Spencer Gibb
+ * @author Joe Athman
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = ConsulDiscoveryClientTests.MyTestConfig.class)
@@ -44,11 +48,26 @@ public class ConsulDiscoveryClientTests {
 
 	@Autowired
 	private ConsulDiscoveryClient discoveryClient;
+	@Autowired
+	private ConsulClient consulClient;
 
 	@Test
 	public void getInstancesForServiceWorks() {
 		List<ServiceInstance> instances = discoveryClient.getInstances("consul");
 		assertNotNull("instances was null", instances);
+		assertFalse("instances was empty", instances.isEmpty());
+
+		ServiceInstance instance = instances.get(0);
+		assertIpAddress(instance);
+	}
+
+	@Test
+	public void getInstancesForServiceRespectsQueryParams() {
+		Response<List<String>> catalogDatacenters = consulClient.getCatalogDatacenters();
+
+		List<String> dataCenterList = catalogDatacenters.getValue();
+		assertFalse("no data centers found", dataCenterList.isEmpty());
+		List<ServiceInstance> instances = discoveryClient.getInstances("consul", new QueryParams(dataCenterList.get(0)));
 		assertFalse("instances was empty", instances.isEmpty());
 
 		ServiceInstance instance = instances.get(0);


### PR DESCRIPTION
For specific services our company only runs them in one of our data centers. To be able to discover the appropriate service we need to pass in a specific data center with the query to Consul. This PR adds the ability to pass a custom `QueryParams` object to the `getInstances` call. It didn't seem like this was possible using the existing Consul client. Added one simple test for this, it's not really easy to test extensively without being able to assume there are multiple DCs available.

This is my first PR to this project so please let me know if there's anything else I need to do.

I have signed the contributor's agreement.