### PR TITLE
add ability to configure a default service tag to query by

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
@@ -115,6 +115,11 @@ public class ConsulDiscoveryProperties {
 	private Map<String, String> serverListQueryTags = new HashMap<>();
 
 	/**
+	 * Tag to query for in service list if one is not listed in serverListQueryTags.
+	 */
+	private String defaultQueryTag;
+
+	/**
 	 * Add the 'passing` parameter to /v1/health/service/serviceName.
 	 * This pushes health check passing to the server.
 	 */
@@ -137,6 +142,16 @@ public class ConsulDiscoveryProperties {
 		this.hostInfo = inetUtils.findFirstNonLoopbackHostInfo();
 		this.ipAddress = this.hostInfo.getIpAddress();
 		this.hostname = this.hostInfo.getHostname();
+	}
+
+	/**
+	 *
+	 * @param serviceId The service who's filtering tag is being looked up
+	 * @return The tag the given service id should be filtered by, or null.
+     */
+	public String getQueryTagForService(String serviceId){
+		String tag = serverListQueryTags.get(serviceId);
+		return tag != null ? tag : defaultQueryTag;
 	}
 
 	public String getHostname() {

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServerList.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServerList.java
@@ -76,7 +76,7 @@ public class ConsulServerList extends AbstractServerList<ConsulServer> {
 	}
 
 	private String getTag() {
-		return this.properties.getServerListQueryTags().get(this.serviceId);
+		return this.properties.getQueryTagForService(this.serviceId);
 	}
 
 	@Override

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryPropertiesTest.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryPropertiesTest.java
@@ -1,0 +1,46 @@
+package org.springframework.cloud.consul.discovery;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.cloud.commons.util.InetUtils;
+import org.springframework.cloud.commons.util.InetUtilsProperties;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ConsulDiscoveryPropertiesTest {
+
+    final String DEFAULT_TAG = "defaultTag";
+    final String MAP_TAG = "mapTag";
+    final String SERVICE_NAME_IN_MAP = "serviceNameInMap";
+    final String SERVICE_NAME_NOT_IN_MAP = "serviceNameNotInMap";
+    ConsulDiscoveryProperties properties;
+    Map<String, String> serverListQueryTags = ImmutableMap.of(SERVICE_NAME_IN_MAP, MAP_TAG);
+
+    @Before
+    public void setUp() throws Exception {
+        properties = new ConsulDiscoveryProperties(new InetUtils(new InetUtilsProperties()));
+        properties.setDefaultQueryTag(DEFAULT_TAG);
+        properties.setServerListQueryTags(serverListQueryTags);
+    }
+
+    @Test
+    public void testReturnsNullWhenNoDefaultAndNotInMap() throws Exception {
+        properties.setDefaultQueryTag(null);
+
+        assertNull(properties.getQueryTagForService(SERVICE_NAME_NOT_IN_MAP));
+    }
+
+    @Test
+    public void testGetTagReturnsDefaultWhenNotInMap() throws Exception {
+        assertEquals(DEFAULT_TAG, properties.getQueryTagForService(SERVICE_NAME_NOT_IN_MAP));
+    }
+
+    @Test
+    public void testGetTagReturnsMapValueWhenInMap() throws Exception {
+        assertEquals(MAP_TAG, properties.getQueryTagForService(SERVICE_NAME_IN_MAP));
+    }
+}


### PR DESCRIPTION
This is an enhancement along the lines of `serverListQueryTags`. Instead of having to define a query tag to filter each serviceId by, you can now add a default query tag that all service id's will be filtered by.

This also adds a convenience method to `ConsulDiscoveryProperties` to select the appropriate tag for a given serviceId, delegating to the default tag if a corresponding tag is not found in the `serverListQueryTags` map.