### PR TITLE
Enabled Consul service customization

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
@@ -16,11 +16,14 @@
 
 package org.springframework.cloud.consul.discovery;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
 import javax.servlet.ServletContext;
 
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +37,7 @@ import com.ecwid.consul.v1.agent.model.NewService;
 
 /**
  * @author Spencer Gibb
+ * @author Venil Noronha
  */
 @Slf4j
 public class ConsulLifecycle extends AbstractDiscoveryLifecycle {
@@ -53,6 +57,10 @@ public class ConsulLifecycle extends AbstractDiscoveryLifecycle {
 	private ServletContext servletContext;
 
 	private NewService service = new NewService();
+
+	@Getter
+	@Setter
+	private List<ConsulServiceCustomizer> serviceCustomizers = new ArrayList<>();
 
 	public ConsulLifecycle(ConsulClient client, ConsulDiscoveryProperties properties, HeartbeatProperties ttlConfig) {
 		this.client = client;
@@ -104,6 +112,12 @@ public class ConsulLifecycle extends AbstractDiscoveryLifecycle {
 				checkPort = service.getPort();
 			}
 			service.setCheck(createCheck(checkPort));
+		}
+
+		if (!this.serviceCustomizers.isEmpty()) {
+			for (ConsulServiceCustomizer serviceCustomizer : serviceCustomizers) {
+				serviceCustomizer.customize(service);
+			}
 		}
 
 		register(service);

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
@@ -17,13 +17,13 @@
 package org.springframework.cloud.consul.discovery;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
 import javax.servlet.ServletContext;
 
-import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,8 +58,6 @@ public class ConsulLifecycle extends AbstractDiscoveryLifecycle {
 
 	private NewService service = new NewService();
 
-	@Getter
-	@Setter
 	private List<ConsulServiceCustomizer> serviceCustomizers = new ArrayList<>();
 
 	public ConsulLifecycle(ConsulClient client, ConsulDiscoveryProperties properties, HeartbeatProperties ttlConfig) {
@@ -232,6 +230,39 @@ public class ConsulLifecycle extends AbstractDiscoveryLifecycle {
 	 */
 	public String getManagementServiceName() {
 		return normalizeForDns(getAppName()) + SEPARATOR + properties.getManagementSuffix();
+	}
+
+	/**
+	 * Set {@link ConsulServiceCustomizer}s that should be applied to the
+	 * {@link NewService}. Calling this method will replace any existing
+	 * customizers.
+	 * 
+	 * @param customizers the customizers to set.
+	 */
+	public void setServiceCustomizers(Collection<? extends ConsulServiceCustomizer> customizers) {
+		Assert.notNull(customizers, "ConsulServiceCustomizers must not be null");
+		this.serviceCustomizers = new ArrayList<ConsulServiceCustomizer>(customizers);
+	}
+
+	/**
+	 * Returns a mutable collection of the {@link ConsulServiceCustomizer}s that
+	 * will be applied to the {@link NewService}.
+	 * 
+	 * @return the customizers that will be applied.
+	 */
+	public Collection<ConsulServiceCustomizer> getServiceCustomizers() {
+		return this.serviceCustomizers;
+	}
+
+	/**
+	 * Add {@link ConsulServiceCustomizer}s that should be used to customize the
+	 * {@link NewService}.
+	 * 
+	 * @param customizers the customizers to add.
+	 */
+	public void addServiceCustomizers(ConsulServiceCustomizer... customizers) {
+		Assert.notNull(customizers, "ConsulServiceCustomizers must not be null");
+		this.serviceCustomizers.addAll(Arrays.asList(customizers));
 	}
 
 	public static String normalizeForDns(String s) {

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
@@ -112,10 +112,8 @@ public class ConsulLifecycle extends AbstractDiscoveryLifecycle {
 			service.setCheck(createCheck(checkPort));
 		}
 
-		if (!this.serviceCustomizers.isEmpty()) {
-			for (ConsulServiceCustomizer serviceCustomizer : serviceCustomizers) {
-				serviceCustomizer.customize(service);
-			}
+		for (ConsulServiceCustomizer serviceCustomizer : serviceCustomizers) {
+			serviceCustomizer.customize(service);
 		}
 
 		register(service);

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServiceCustomizer.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServiceCustomizer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.discovery;
+
+import com.ecwid.consul.v1.agent.model.NewService;
+
+/**
+ * Callback interface that can be used to customize a Consul {@link NewService}.
+ * 
+ * @author Venil Noronha
+ */
+public interface ConsulServiceCustomizer {
+
+	/**
+	 * Customize the Consul service.
+	 * 
+	 * @param service the {@link NewService} to customize.
+	 */
+	public void customize(NewService service);
+
+}

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleServiceCustomizerTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleServiceCustomizerTests.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.discovery;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.InOrder;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.actuate.autoconfigure.ManagementServerProperties;
+import org.springframework.cloud.commons.util.InetUtils;
+import org.springframework.cloud.commons.util.InetUtilsProperties;
+import org.springframework.context.ApplicationContext;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.agent.model.NewService;
+
+/**
+ * 
+ * @author Venil Noronha
+ */
+public class ConsulLifecycleServiceCustomizerTests {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void setNullServiceCustomizersThrows() {
+		ConsulLifecycle lifecycle = getLifecycle();
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("ConsulServiceCustomizers must not be null");
+		lifecycle.setServiceCustomizers(null);
+	}
+
+	@Test
+	public void addNullServiceCustomizersThrows() {
+		ConsulLifecycle lifecycle = getLifecycle();
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("ConsulServiceCustomizers must not be null");
+		lifecycle.addServiceCustomizers((ConsulServiceCustomizer[]) null);
+	}
+
+	@Test
+	public void serviceCustomizations() throws Exception {
+		ConsulLifecycle lifecycle = getLifecycle();
+		ConsulServiceCustomizer[] customizers = new ConsulServiceCustomizer[4];
+		for (int i = 0; i < customizers.length; i++) {
+			customizers[i] = mock(ConsulServiceCustomizer.class);
+		}
+		lifecycle.setServiceCustomizers(Arrays.asList(customizers[0], customizers[1]));
+		lifecycle.addServiceCustomizers(customizers[2], customizers[3]);
+		InOrder ordered = inOrder((Object[]) customizers);
+		lifecycle.start();
+		for (ConsulServiceCustomizer customizer : customizers) {
+			ordered.verify(customizer).customize((NewService) anyObject());
+		}
+	}
+
+	private ConsulLifecycle getLifecycle() {
+		ConsulClient client = new ConsulClient();
+		InetUtils inetUtils = new InetUtils(new InetUtilsProperties());
+		ConsulDiscoveryProperties discoveryProperties = new ConsulDiscoveryProperties(inetUtils);
+		discoveryProperties.setServiceName("testService");
+		discoveryProperties.setInstanceId("testInstance");
+		HeartbeatProperties heartbeatProperties = mock(HeartbeatProperties.class);
+		ConsulLifecycle lifecycle = new ConsulLifecycle(client, discoveryProperties, heartbeatProperties);
+		ApplicationContext applicationContext = mock(ApplicationContext.class);
+		NoSuchBeanDefinitionException beanException = new NoSuchBeanDefinitionException("Bean not found");
+		when(applicationContext.getBean(ManagementServerProperties.class)).thenThrow(beanException);
+		lifecycle.setApplicationContext(applicationContext);
+		lifecycle.setConfiguredPort(8000);
+		ConsulLifecycle lifecycleSpy = spy(lifecycle);
+		doAnswer(new Answer<Void>() {
+			@Override public Void answer(InvocationOnMock invocation) throws Throwable {
+				return null;
+			}
+		}).when(lifecycleSpy).register((NewService) any());
+		return lifecycleSpy;
+	}
+
+}


### PR DESCRIPTION
I've created a callback interface called `ConsulServiceCustomizer`. Several implementations of this callback can be wired to `ConsulLifecycle` during bean creation. `ConsulLifecycle` would execute these callbacks as the last step in its `register()` method. `ConsulServiceCustomizer` can be used to add additional tags / configure other parameters of the service. See #109.

Please review and pull. My CLA number is 149720151120072904.

Thanks,
Venil Noronha