### PR TITLE
log consul deregister calls

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
@@ -192,6 +192,7 @@ public class ConsulLifecycle extends AbstractDiscoveryLifecycle {
 		if (ttlScheduler != null) {
 			ttlScheduler.remove(serviceId);
 		}
+		log.info("Deregistering service with consul: {}", serviceId);
 		client.agentServiceDeregister(serviceId);
 	}
 


### PR DESCRIPTION
This pull request adds logging of consul deregister calls.

Currently register calls are logged, but deregister calls are not. When debugging why a service was not deregistered, I noticed the register call in the log file but not the deregister call. My initial assumption was that spring-cloud-consul did not deregister the service, which turned out not to be the case (it just wasn't logged).

With this pull request we will create consistent logging across the register and deregister calls.