### PR TITLE
Fixes #189 - Improve Consul TTL Check management

### DIFF
--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/TtlSchedulerRemoveTest.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/TtlSchedulerRemoveTest.java
@@ -1,0 +1,76 @@
+package org.springframework.cloud.consul.discovery;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.QueryParams;
+import com.ecwid.consul.v1.Response;
+import com.ecwid.consul.v1.health.model.Check;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.consul.ConsulAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.List;
+
+import static com.ecwid.consul.v1.health.model.Check.CheckStatus.CRITICAL;
+import static com.ecwid.consul.v1.health.model.Check.CheckStatus.PASSING;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Stéphane Leroy
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@SpringApplicationConfiguration(classes = TtlSchedulerRemoveTestConfig.class)
+@WebIntegrationTest(value = {"spring.application.name=ttlSchedulerRemove",
+        "spring.cloud.consul.discovery.instanceId=ttlSchedulerRemove-id",
+        "spring.cloud.consul.discovery.heartbeat.enabled=true",
+        "spring.cloud.consul.discovery.heartbeat.ttlValue=2"},
+        randomPort = true)
+public class TtlSchedulerRemoveTest {
+
+    @Autowired
+    private ConsulClient consul;
+
+    @Autowired
+    private TtlScheduler ttlScheduler;
+
+    @Test
+    public void should_not_send_check_if_service_removed() throws InterruptedException {
+        Thread.sleep(1000);  // wait for Ttlscheduler to send a check to consul.
+        Check serviceCheck = getCheckForService("ttlSchedulerRemove");
+        assertThat("Service check is in wrong state", serviceCheck.getStatus(), equalTo(PASSING));
+
+        // Remove service from TtlScheduler and wait for TTL to expired.
+        ttlScheduler.remove("ttlSchedulerRemove-id");
+        Thread.sleep(2100);
+        serviceCheck = getCheckForService("ttlSchedulerRemove");
+        assertThat("Service check is in wrong state", serviceCheck.getStatus(), equalTo(CRITICAL));
+    }
+
+    private Check getCheckForService(String serviceId) {
+        Response<List<Check>> checkResponse = consul.getHealthChecksForService(serviceId, QueryParams.DEFAULT);
+        if(checkResponse.getValue().size()>0) {
+            return checkResponse.getValue().get(0);
+        }
+        return null;
+    }
+
+}
+
+@Configuration
+@EnableDiscoveryClient
+@EnableAutoConfiguration
+@Import({ ConsulAutoConfiguration.class, ConsulDiscoveryClientConfiguration.class })
+class TtlSchedulerRemoveTestConfig {
+
+}

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/TtlSchedulerTest.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/TtlSchedulerTest.java
@@ -1,0 +1,71 @@
+package org.springframework.cloud.consul.discovery;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.QueryParams;
+import com.ecwid.consul.v1.Response;
+import com.ecwid.consul.v1.health.model.Check;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.consul.ConsulAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.List;
+
+import static com.ecwid.consul.v1.health.model.Check.CheckStatus.CRITICAL;
+import static com.ecwid.consul.v1.health.model.Check.CheckStatus.PASSING;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Stéphane Leroy
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@SpringApplicationConfiguration(classes = TtlSchedulerTestConfig.class)
+@WebIntegrationTest(value = {"spring.application.name=ttlScheduler",
+        "spring.cloud.consul.discovery.instanceId=ttlScheduler-id",
+        "spring.cloud.consul.discovery.heartbeat.enabled=true",
+        "spring.cloud.consul.discovery.heartbeat.ttlValue=2",
+        "management.port=0"},
+        randomPort = true)
+public class TtlSchedulerTest {
+
+    @Autowired
+    private ConsulClient consul;
+
+    @Test
+    public void should_send_a_check_before_ttl_for_all_services() throws InterruptedException {
+        Thread.sleep(2100); // Wait for TTL to expired (TTL is set to 2 seconds)
+
+        Check serviceCheck = getCheckForService("ttlScheduler");
+        assertThat("Service check is in wrong state", serviceCheck.getStatus(), equalTo(PASSING));
+        Check serviceManagementCheck = getCheckForService("ttlScheduler-management");
+        assertThat("Service management heck in wrong state", serviceManagementCheck.getStatus(), equalTo(PASSING));
+    }
+
+    private Check getCheckForService(String serviceId) {
+        Response<List<Check>> checkResponse = consul.getHealthChecksForService(serviceId, QueryParams.DEFAULT);
+        if(checkResponse.getValue().size()>0) {
+            return checkResponse.getValue().get(0);
+        }
+        return null;
+    }
+
+}
+
+@Configuration
+@EnableDiscoveryClient
+@EnableAutoConfiguration
+@Import({ ConsulAutoConfiguration.class, ConsulDiscoveryClientConfiguration.class })
+class TtlSchedulerTestConfig {
+
+}


### PR DESCRIPTION
Remove spring.cloud.consul.discovery.heartbeat.fixedRate property and use a TaskScheduler (with FixedRateTrigger) to send Consul checks