### PR TITLE
resolve incorrect version of 'io.reactivex:rxjava' issue

### DIFF
--- a/spring-cloud-starter-consul-discovery/pom.xml
+++ b/spring-cloud-starter-consul-discovery/pom.xml
@@ -38,20 +38,8 @@
 			<artifactId>spring-cloud-starter-archaius</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.netflix.ribbon</groupId>
-			<artifactId>ribbon</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.netflix.ribbon</groupId>
-			<artifactId>ribbon-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.netflix.ribbon</groupId>
-			<artifactId>ribbon-httpclient</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.netflix.ribbon</groupId>
-			<artifactId>ribbon-loadbalancer</artifactId>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-ribbon</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>


### PR DESCRIPTION
resolve incorrect version of 'io.reactivex:rxjava' issue in 'spring-cloud-starter-consul-discovery' module

If I only include dependency 'spring-cloud-starter-consul-discovery'(1.0.0.RELEASE), the application will startup failed by the exception `java.lang.ClassNotFoundException: rx.Single`. The class `rx.Single` is used in `RxJavaAutoConfiguration`(spring-cloud-netflix-core-1.1.0.RELEASE).

***mvn dependency:tree -Dincludes=io.reactivex:rxjava*** results:

```
[INFO]       \- org.springframework.cloud:spring-cloud-starter-consul-discovery:jar:1.0.0.RELEASE:compile
[INFO]          \- com.netflix.ribbon:ribbon:jar:2.1.5:compile
[INFO]             \- io.reactivex:rxjava:jar:1.0.10:runtime
```
There is no `rx.Single` in `io.reactivex:rxjava:jar:1.0.10`.