### PR TITLE
Fix example segment of code

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-consul.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-consul.adoc
@@ -123,7 +123,7 @@ You can also use the `org.springframework.cloud.client.discovery.DiscoveryClient
 private DiscoveryClient discoveryClient;
 
 public String serviceUrl() {
-    List<ServiceInstance> list = client.getInstances("STORES");
+    List<ServiceInstance> list = discoveryClient.getInstances("STORES");
     if (list != null && list.size() > 0 ) {
         return list.get(0).getUri();
     }


### PR DESCRIPTION
The discovery client example code attempts to call a `getInstances` function on a non existing client, this should be `discoveryClient`