### PR TITLE
Skip refresh if value is null

### DIFF
--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConfigWatch.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConfigWatch.java
@@ -84,6 +84,10 @@ public class ConfigWatch implements Closeable, ApplicationEventPublisherAware {
 							new QueryParams(this.properties.getWatch().getWaitTime(),
 									currentIndex));
 
+                    // if the value is null, ignore it
+                    if (response.getValue() == null)
+                        continue;
+
 					Long newIndex = response.getConsulIndex();
 
 					if (newIndex != null && !newIndex.equals(currentIndex)) {


### PR DESCRIPTION
If the prefix does not exist in consul, the value in the response
object will be null. In this case, do not publish a refresh event.

I'm told to say that SAS has a signed Committers Confidentiality
Agreement as well.