### PR TITLE
Enables failFast setting for consul service registration

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
@@ -141,9 +141,9 @@ public class ConsulDiscoveryProperties {
 
 	/**
 	 * Throw exceptions during service registration if true, otherwise, log
-	 * warnings (defaults to false).
+	 * warnings (defaults to true).
 	 */
-	private boolean failFast = false;
+	private boolean failFast = true;
 
 	@SuppressWarnings("unused")
 	private ConsulDiscoveryProperties() {}

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import lombok.Setter;
  * Defines configuration for service discovery and registration.
  *
  * @author Spencer Gibb
+ * @author Venil Noronha
  */
 @ConfigurationProperties("spring.cloud.consul.discovery")
 @Data
@@ -137,6 +138,12 @@ public class ConsulDiscoveryProperties {
 	 * Register health check in consul. Useful during development of a service.
 	 */
 	private boolean registerHealthCheck = true;
+
+	/**
+	 * Throw exceptions during service registration if true, otherwise, log
+	 * warnings (defaults to false).
+	 */
+	private boolean failFast = false;
 
 	@SuppressWarnings("unused")
 	private ConsulDiscoveryProperties() {}

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedPropsTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedPropsTests.java
@@ -42,8 +42,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Spencer Gibb
@@ -58,7 +58,7 @@ import static org.junit.Assert.assertTrue;
 		"spring.cloud.consul.discovery.hostname=myhost",
 		"spring.cloud.consul.discovery.ipAddress=10.0.0.1",
 		"spring.cloud.consul.discovery.registerHealthCheck=false",
-		"spring.cloud.consul.discovery.failFast=true" }, randomPort = true)
+		"spring.cloud.consul.discovery.failFast=false" }, randomPort = true)
 public class ConsulLifecycleCustomizedPropsTests {
 
 	@Autowired
@@ -92,8 +92,8 @@ public class ConsulLifecycleCustomizedPropsTests {
 	}
 
 	@Test
-	public void testFailFastEnabled() {
-		assertTrue("property failFast was wrong", this.properties.isFailFast());
+	public void testFailFastDisabled() {
+		assertFalse("property failFast was wrong", this.properties.isFailFast());
 	}
 
 }

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedPropsTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedPropsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,9 +43,11 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Spencer Gibb
+ * @author Venil Noronha
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -55,7 +57,8 @@ import static org.junit.Assert.assertThat;
 		"spring.cloud.consul.discovery.port=4452",
 		"spring.cloud.consul.discovery.hostname=myhost",
 		"spring.cloud.consul.discovery.ipAddress=10.0.0.1",
-		"spring.cloud.consul.discovery.registerHealthCheck=false", }, randomPort = true)
+		"spring.cloud.consul.discovery.registerHealthCheck=false",
+		"spring.cloud.consul.discovery.failFast=true" }, randomPort = true)
 public class ConsulLifecycleCustomizedPropsTests {
 
 	@Autowired
@@ -87,6 +90,12 @@ public class ConsulLifecycleCustomizedPropsTests {
 		List<Check> checks = checkResponse.getValue();
 		assertThat("checks was wrong size", checks, hasSize(0));
 	}
+
+	@Test
+	public void testFailFastEnabled() {
+		assertTrue("property failFast was wrong", this.properties.isFailFast());
+	}
+
 }
 
 @Configuration

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
 
 package org.springframework.cloud.consul.discovery;
 
+import com.ecwid.consul.ConsulException;
 import com.ecwid.consul.v1.ConsulClient;
 import com.ecwid.consul.v1.Response;
+import com.ecwid.consul.v1.agent.model.NewService;
 import com.ecwid.consul.v1.agent.model.Service;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -43,11 +45,13 @@ import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Spencer Gibb
+ * @author Venil Noronha
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @SpringApplicationConfiguration(classes = TestConfig.class)
-@WebIntegrationTest(value = "spring.application.name=myTestService1-F::something", randomPort = true)
+@WebIntegrationTest(value = { "spring.application.name=myTestService1-F::something",
+		"spring.cloud.consul.discovery.failFast=true" }, randomPort = true)
 public class ConsulLifecycleTests {
 
 	@Autowired
@@ -81,6 +85,11 @@ public class ConsulLifecycleTests {
 		assertEquals("abc1", ConsulLifecycle.normalizeForDns("abc1"));
 		assertEquals("ab-c1", ConsulLifecycle.normalizeForDns("ab:c1"));
 		assertEquals("ab-c1", ConsulLifecycle.normalizeForDns("ab::c1"));
+	}
+
+	@Test(expected = ConsulException.class)
+	public void testFailFastEnabled() {
+		lifecycle.register(new NewService());
 	}
 
 	@Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
This PR enables utilization of the `failFast` configuration property while registering a consul service. Refer #175 for more information.

I've signed the CLA. Please review and pull.

Thanks,
Venil
