### PR TITLE
Adds property to deregister services in critical longer than timeout

### DIFF
--- a/spring-cloud-consul-dependencies/pom.xml
+++ b/spring-cloud-consul-dependencies/pom.xml
@@ -14,7 +14,7 @@
 	<name>spring-cloud-consul-dependencies</name>
 	<description>Spring Cloud Consul Dependencies</description>
 	<properties>
-		<consul-api.version>1.1.11</consul-api.version>
+		<consul-api.version>1.2.1</consul-api.version>
 		<gson.version>2.3.1</gson.version>
 		<httpclient.version>4.5</httpclient.version>
 		<httpcore.version>4.4.1</httpcore.version>

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import lombok.Setter;
  * Defines configuration for service discovery and registration.
  *
  * @author Spencer Gibb
+ * @author Donnabell Dmello
  */
 @ConfigurationProperties("spring.cloud.consul.discovery")
 @Data
@@ -69,6 +70,9 @@ public class ConsulDiscoveryProperties {
 
 	/** Timeout for health check (e.g. 10s) */
 	private String healthCheckTimeout;
+
+	/** Timeout to deregister services critical for longer than timeout. */
+	private String healthCheckCriticalTimeout;
 
 	/** IP address to use when accessing service (must also set preferIpAddress
 			to use) */

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Spencer Gibb
+ * @author Donnabell Dmello
  */
 @Slf4j
 public class ConsulLifecycle extends AbstractDiscoveryLifecycle {
@@ -136,6 +137,7 @@ public class ConsulLifecycle extends AbstractDiscoveryLifecycle {
 		}
 		check.setInterval(properties.getHealthCheckInterval());
 		check.setTimeout(properties.getHealthCheckTimeout());
+		check.setDeregisterCriticalServiceAfter(properties.getHealthCheckCriticalTimeout());
 		return check;
 	}
 


### PR DESCRIPTION
This PR adds a config property `healthCheckCriticalTimeout` which enables deregistering services that are in critical for longer than timeout. I have updated the consul API version to `1.2.1`.
(Refer to #210 for more information)

Thanks,
Donnabell
