### PR TITLE
Avoid NPE if YAML/PROPERTIES data value is empty

### DIFF
--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySource.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySource.java
@@ -119,6 +119,10 @@ public class ConsulPropertySource extends EnumerablePropertySource<ConsulClient>
 
 	protected void parseValue(GetValue getValue, ConsulConfigProperties.Format format) {
 		String value = getValue.getDecodedValue();
+		if (value == null) {
+			return;
+		}
+
 		Properties props = generateProperties(value, format);
 
 		for (Map.Entry entry : props.entrySet()) {

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulPropertySourceTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulPropertySourceTests.java
@@ -94,6 +94,19 @@ public class ConsulPropertySourceTests {
 		assertProperties(source, "fooymlval", "8080");
 	}
 
+	@Test
+	public void testEmptyYaml() {
+		// yaml file property
+		String yamlContext = prefix + "/yaml";
+		client.setKVValue(yamlContext+"/data", "");
+
+		ConsulConfigProperties configProperties = new ConsulConfigProperties();
+		configProperties.setFormat(ConsulConfigProperties.Format.YAML);
+		ConsulPropertySource source = new ConsulPropertySource(yamlContext, client, configProperties);
+		// Should NOT through a NPE
+		source.init();
+	}
+
 	private ConsulPropertySource getConsulPropertySource(ConsulConfigProperties configProperties, String context) {
 		ConsulPropertySource source = new ConsulPropertySource(context, client, configProperties);
 		source.init();


### PR DESCRIPTION
Can happen if empty file content is sent to Consul's K/V store or data is manually edited via the UI.