### PR TITLE
YAML-based properties are not converted to String anymore

### DIFF
--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySource.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySource.java
@@ -46,7 +46,7 @@ public class ConsulPropertySource extends EnumerablePropertySource<ConsulClient>
 	private String context;
 	private ConsulConfigProperties configProperties;
 
-	private final Map<String, String> properties = new LinkedHashMap<>();
+	private final Map<String, Object> properties = new LinkedHashMap<>();
 
 	public ConsulPropertySource(String context, ConsulClient source,
 			ConsulConfigProperties configProperties) {
@@ -123,7 +123,7 @@ public class ConsulPropertySource extends EnumerablePropertySource<ConsulClient>
 
 		for (Map.Entry entry : props.entrySet()) {
 			properties
-					.put(entry.getKey().toString(), entry.getValue().toString());
+					.put(entry.getKey().toString(), entry.getValue());
 		}
 	}
 
@@ -164,7 +164,7 @@ public class ConsulPropertySource extends EnumerablePropertySource<ConsulClient>
 		return new String(decodeFromString(value));
 	}
 
-	protected Map<String, String> getProperties() {
+	protected Map<String, Object> getProperties() {
 		return properties;
 	}
 

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulPropertySourceTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulPropertySourceTests.java
@@ -63,9 +63,9 @@ public class ConsulPropertySourceTests {
 		assertProperties(source, "fookvval", "8080");
 	}
 
-	private void assertProperties(ConsulPropertySource source, String fooval, String barval) {
-		assertThat("fooprop was wrong", (String)source.getProperty("fooprop"), is(equalTo(fooval)));
-		assertThat("bar.prop was wrong", (String)source.getProperty("bar.prop"), is(equalTo(barval)));
+	private void assertProperties(ConsulPropertySource source, Object fooval, Object barval) {
+		assertThat("fooprop was wrong", source.getProperty("fooprop"), is(equalTo(fooval)));
+		assertThat("bar.prop was wrong", source.getProperty("bar.prop"), is(equalTo(barval)));
 	}
 
 	@Test
@@ -91,7 +91,7 @@ public class ConsulPropertySourceTests {
 		configProperties.setFormat(ConsulConfigProperties.Format.YAML);
 		ConsulPropertySource source = getConsulPropertySource(configProperties, yamlContext);
 
-		assertProperties(source, "fooymlval", "8080");
+		assertProperties(source, "fooymlval", 8080);
 	}
 
 	private ConsulPropertySource getConsulPropertySource(ConsulConfigProperties configProperties, String context) {


### PR DESCRIPTION
This allows for typesafe usage of values.

We stumbled upon this as we store/retrieve Apache Storm configuration via spring-cloud-consul-config. Storm validates the given configuration and rejects type mismatches.