### PR TITLE
ConsulServerList#toString(): use StringBuilder instead of StringBuffer

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServerList.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServerList.java
@@ -117,7 +117,7 @@ public class ConsulServerList extends AbstractServerList<ConsulServer> {
 
 	@Override
 	public String toString() {
-		final StringBuffer sb = new StringBuffer("ConsulServerList{");
+		final StringBuilder sb = new StringBuilder("ConsulServerList{");
 		sb.append("serviceId='").append(serviceId).append('\'');
 		sb.append(", tag=").append(getTag());
 		sb.append('}');


### PR DESCRIPTION
It's unnecessary to use `StringBuffer` because that the instance of `StringBuffer` is not shared between threads.