### PR TITLE
fix ipv6 formatting for consul API

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServerUtils.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServerUtils.java
@@ -36,58 +36,59 @@ import lombok.extern.apachecommons.CommonsLog;
 @CommonsLog
 public class ConsulServerUtils {
 
-	public static String findHost(HealthService healthService) {
-		HealthService.Service service = healthService.getService();
-		HealthService.Node node = healthService.getNode();
+    public static String findHost(HealthService healthService) {
+        HealthService.Service service = healthService.getService();
+        HealthService.Node node = healthService.getNode();
 
-		if (StringUtils.hasText(service.getAddress())) {
-			return fixIPv6Address(service.getAddress());
-		} else if (StringUtils.hasText(node.getAddress())) {
-			return fixIPv6Address(node.getAddress());
-		}
-		return node.getNode();
-	}
+        if (StringUtils.hasText(service.getAddress())) {
+            return fixIPv6Address(service.getAddress());
+        } else if (StringUtils.hasText(node.getAddress())) {
+            return fixIPv6Address(node.getAddress());
+        }
+        return node.getNode();
+    }
 
-	public static String fixIPv6Address(String address) {
-		try {
-			InetAddress inetAdr = InetAddress.getByName(address);
-			if (inetAdr instanceof Inet6Address) {
-				return "[" + inetAdr.getHostName() + "]";
-			}
-		} catch (UnknownHostException e) {
-			throw new RuntimeException(e);
-		}
-		return address;
-	}
+    public static String fixIPv6Address(String address) {
+        try {
+            InetAddress inetAdr = InetAddress.getByName(address);
+            if (inetAdr instanceof Inet6Address) {
+                return "[" + inetAdr.getHostName() + "]";
+            }
+            return address;
+        } catch (UnknownHostException e) {
+            log.debug("Not InetAddress: " + address + " , resolved as is.");
+            return address;
+        }
+    }
 
 
-	public static Map<String, String> getMetadata(HealthService healthService) {
-		return getMetadata(healthService.getService().getTags());
-	}
+    public static Map<String, String> getMetadata(HealthService healthService) {
+        return getMetadata(healthService.getService().getTags());
+    }
 
-	public static Map<String, String> getMetadata(List<String> tags) {
-		LinkedHashMap<String, String> metadata = new LinkedHashMap<>();
-		if (tags != null) {
-			for (String tag : tags) {
-				String[] parts = StringUtils.delimitedListToStringArray(tag, "=");
-				switch (parts.length) {
-					case 0:
-						break;
-					case 1:
-						metadata.put(parts[0], parts[0]);
-						break;
-					case 2:
-						metadata.put(parts[0], parts[1]);
-						break;
-					default:
-						String[] end = Arrays.copyOfRange(parts, 1, parts.length);
-						metadata.put(parts[0], StringUtils.arrayToDelimitedString(end, "="));
-						break;
-				}
+    public static Map<String, String> getMetadata(List<String> tags) {
+        LinkedHashMap<String, String> metadata = new LinkedHashMap<>();
+        if (tags != null) {
+            for (String tag : tags) {
+                String[] parts = StringUtils.delimitedListToStringArray(tag, "=");
+                switch (parts.length) {
+                    case 0:
+                        break;
+                    case 1:
+                        metadata.put(parts[0], parts[0]);
+                        break;
+                    case 2:
+                        metadata.put(parts[0], parts[1]);
+                        break;
+                    default:
+                        String[] end = Arrays.copyOfRange(parts, 1, parts.length);
+                        metadata.put(parts[0], StringUtils.arrayToDelimitedString(end, "="));
+                        break;
+                }
 
-			}
-		}
+            }
+        }
 
-		return metadata;
-	}
+        return metadata;
+    }
 }

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServerUtils.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServerUtils.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.consul.discovery;
 
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -38,12 +41,25 @@ public class ConsulServerUtils {
 		HealthService.Node node = healthService.getNode();
 
 		if (StringUtils.hasText(service.getAddress())) {
-			return service.getAddress();
+			return fixIPv6Address(service.getAddress());
 		} else if (StringUtils.hasText(node.getAddress())) {
-			return node.getAddress();
+			return fixIPv6Address(node.getAddress());
 		}
 		return node.getNode();
 	}
+
+	public static String fixIPv6Address(String address) {
+		try {
+			InetAddress inetAdr = InetAddress.getByName(address);
+			if (inetAdr instanceof Inet6Address) {
+				return "[" + inetAdr.getHostName() + "]";
+			}
+		} catch (UnknownHostException e) {
+			throw new RuntimeException(e);
+		}
+		return address;
+	}
+
 
 	public static Map<String, String> getMetadata(HealthService healthService) {
 		return getMetadata(healthService.getService().getTags());

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServerUtils.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServerUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * 		http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,64 +31,64 @@ import org.springframework.util.StringUtils;
 import lombok.extern.apachecommons.CommonsLog;
 
 /**
- * @author Spencer Gibb
+ * @author Spencer Gibb, Semenkov Alexey
  */
 @CommonsLog
 public class ConsulServerUtils {
 
-    public static String findHost(HealthService healthService) {
-        HealthService.Service service = healthService.getService();
-        HealthService.Node node = healthService.getNode();
+	public static String findHost(HealthService healthService) {
+		HealthService.Service service = healthService.getService();
+		HealthService.Node node = healthService.getNode();
 
-        if (StringUtils.hasText(service.getAddress())) {
-            return fixIPv6Address(service.getAddress());
-        } else if (StringUtils.hasText(node.getAddress())) {
-            return fixIPv6Address(node.getAddress());
-        }
-        return node.getNode();
-    }
+		if (StringUtils.hasText(service.getAddress())) {
+			return fixIPv6Address(service.getAddress());
+		} else if (StringUtils.hasText(node.getAddress())) {
+			return fixIPv6Address(node.getAddress());
+		}
+		return node.getNode();
+	}
 
-    public static String fixIPv6Address(String address) {
-        try {
-            InetAddress inetAdr = InetAddress.getByName(address);
-            if (inetAdr instanceof Inet6Address) {
-                return "[" + inetAdr.getHostName() + "]";
-            }
-            return address;
-        } catch (UnknownHostException e) {
-            log.debug("Not InetAddress: " + address + " , resolved as is.");
-            return address;
-        }
-    }
+	public static String fixIPv6Address(String address) {
+		try {
+			InetAddress inetAdr = InetAddress.getByName(address);
+			if (inetAdr instanceof Inet6Address) {
+				return "[" + inetAdr.getHostName() + "]";
+			}
+			return address;
+		} catch (UnknownHostException e) {
+			log.debug("Not InetAddress: " + address + " , resolved as is.");
+			return address;
+		}
+	}
 
 
-    public static Map<String, String> getMetadata(HealthService healthService) {
-        return getMetadata(healthService.getService().getTags());
-    }
+	public static Map<String, String> getMetadata(HealthService healthService) {
+		return getMetadata(healthService.getService().getTags());
+	}
 
-    public static Map<String, String> getMetadata(List<String> tags) {
-        LinkedHashMap<String, String> metadata = new LinkedHashMap<>();
-        if (tags != null) {
-            for (String tag : tags) {
-                String[] parts = StringUtils.delimitedListToStringArray(tag, "=");
-                switch (parts.length) {
-                    case 0:
-                        break;
-                    case 1:
-                        metadata.put(parts[0], parts[0]);
-                        break;
-                    case 2:
-                        metadata.put(parts[0], parts[1]);
-                        break;
-                    default:
-                        String[] end = Arrays.copyOfRange(parts, 1, parts.length);
-                        metadata.put(parts[0], StringUtils.arrayToDelimitedString(end, "="));
-                        break;
-                }
+	public static Map<String, String> getMetadata(List<String> tags) {
+		LinkedHashMap<String, String> metadata = new LinkedHashMap<>();
+		if (tags != null) {
+			for (String tag : tags) {
+				String[] parts = StringUtils.delimitedListToStringArray(tag, "=");
+				switch (parts.length) {
+					case 0:
+						break;
+					case 1:
+						metadata.put(parts[0], parts[0]);
+						break;
+					case 2:
+						metadata.put(parts[0], parts[1]);
+						break;
+					default:
+						String[] end = Arrays.copyOfRange(parts, 1, parts.length);
+						metadata.put(parts[0], StringUtils.arrayToDelimitedString(end, "="));
+						break;
+				}
 
-            }
-        }
+			}
+		}
 
-        return metadata;
-    }
+		return metadata;
+	}
 }

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulServerUtilsTest.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulServerUtilsTest.java
@@ -1,0 +1,26 @@
+package org.springframework.cloud.consul.discovery;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Alexey Semenkov
+ **/
+public class ConsulServerUtilsTest {
+
+    @Test
+    public void testAddressFormat() {
+        String s = ConsulServerUtils.fixIPv6Address("fc00:ec:cd::242:ac11:c");
+        assertEquals("[fc00:ec:cd:0:0:242:ac11:c]", s);
+
+        String s2 = ConsulServerUtils.fixIPv6Address("[fc00:ec:cd::242:ac11:c]");
+        assertEquals("[fc00:ec:cd:0:0:242:ac11:c]", s2);
+
+        String s3 = ConsulServerUtils.fixIPv6Address("192.168.0.1");
+        assertEquals("192.168.0.1", s3);
+
+        String s4 = ConsulServerUtils.fixIPv6Address("projects.spring.io");
+        assertEquals("projects.spring.io", s4);
+    }
+}

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulServerUtilsTest.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulServerUtilsTest.java
@@ -11,8 +11,8 @@ public class ConsulServerUtilsTest {
 
     @Test
     public void testAddressFormat() {
-        String s = ConsulServerUtils.fixIPv6Address("fc00:ec:cd::242:ac11:c");
-        assertEquals("[fc00:ec:cd:0:0:242:ac11:c]", s);
+        String s1 = ConsulServerUtils.fixIPv6Address("fc00:ec:cd::242:ac11:c");
+        assertEquals("[fc00:ec:cd:0:0:242:ac11:c]", s1);
 
         String s2 = ConsulServerUtils.fixIPv6Address("[fc00:ec:cd::242:ac11:c]");
         assertEquals("[fc00:ec:cd:0:0:242:ac11:c]", s2);
@@ -22,5 +22,8 @@ public class ConsulServerUtilsTest {
 
         String s4 = ConsulServerUtils.fixIPv6Address("projects.spring.io");
         assertEquals("projects.spring.io", s4);
+
+        String s5 = ConsulServerUtils.fixIPv6Address("veryLongHostName");
+        assertEquals("veryLongHostName", s5);
     }
 }

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulServerUtilsTest.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulServerUtilsTest.java
@@ -5,25 +5,26 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author Alexey Semenkov
+ * @author Semenkov Alexey
  **/
 public class ConsulServerUtilsTest {
 
-    @Test
-    public void testAddressFormat() {
-        String s1 = ConsulServerUtils.fixIPv6Address("fc00:ec:cd::242:ac11:c");
-        assertEquals("[fc00:ec:cd:0:0:242:ac11:c]", s1);
+	@Test
+	public void testAddressFormat() {
+		String s1 = ConsulServerUtils.fixIPv6Address("fc00:ec:cd::242:ac11:c");
+		assertEquals("[fc00:ec:cd:0:0:242:ac11:c]", s1);
 
-        String s2 = ConsulServerUtils.fixIPv6Address("[fc00:ec:cd::242:ac11:c]");
-        assertEquals("[fc00:ec:cd:0:0:242:ac11:c]", s2);
+		String s2 = ConsulServerUtils.fixIPv6Address("[fc00:ec:cd::242:ac11:c]");
+		assertEquals("[fc00:ec:cd:0:0:242:ac11:c]", s2);
 
-        String s3 = ConsulServerUtils.fixIPv6Address("192.168.0.1");
-        assertEquals("192.168.0.1", s3);
+		String s3 = ConsulServerUtils.fixIPv6Address("192.168.0.1");
+		assertEquals("192.168.0.1", s3);
 
-        String s4 = ConsulServerUtils.fixIPv6Address("projects.spring.io");
-        assertEquals("projects.spring.io", s4);
+		String s4 = ConsulServerUtils.fixIPv6Address("projects.spring.io");
+		assertEquals("projects.spring.io", s4);
 
-        String s5 = ConsulServerUtils.fixIPv6Address("veryLongHostName");
-        assertEquals("veryLongHostName", s5);
-    }
+		String s5 = ConsulServerUtils.fixIPv6Address("veryLongHostName");
+		assertEquals("veryLongHostName", s5);
+
+	}
 }


### PR DESCRIPTION
When consul api return IPv6 address - spring cloud consul can't parse it correctly - using it as is.
Added IPv6 address format modification.