### PR TITLE
ConfigWatch not issuing refreshEvent on new context

### DIFF
--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConfigWatch.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConfigWatch.java
@@ -83,6 +83,9 @@ public class ConfigWatch implements Closeable, ApplicationEventPublisherAware {
 					Long currentIndex = this.consulIndexes.get(context);
 					if (currentIndex == null) {
 						currentIndex = -1L;
+   						// Add unique seed value to the stored indexes to indicate
+						// that this method has been called once on this context
+						this.consulIndexes.put(context, -2L);
 					}
 
 					// use the consul ACL token if found


### PR DESCRIPTION
The refreshEvent() is not sent when the context is created after
the service has started. This is a simple change to indicate
that watchConfigKeyValues() has been called once even if the
context doesn't exist.

intended to fix gh-231