### PR TITLE
Get seed indexes from consul in property source locator.

### DIFF
--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConfigWatch.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConfigWatch.java
@@ -21,10 +21,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import javax.annotation.PostConstruct;
+
 import org.springframework.cloud.endpoint.event.RefreshEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
@@ -38,8 +39,6 @@ import static org.springframework.cloud.consul.config.ConsulConfigProperties.For
 
 import lombok.Data;
 import lombok.extern.apachecommons.CommonsLog;
-
-import javax.annotation.PostConstruct;
 
 /**
  * @author Spencer Gibb
@@ -136,10 +135,6 @@ public class ConfigWatch implements Closeable, ApplicationEventPublisherAware {
 	@Override
 	public void close() {
 		this.running.compareAndSet(true, false);
-	}
-
-	/* for testing */ LinkedHashMap<String, Long> getConsulIndexes() {
-		return this.consulIndexes;
 	}
 
 	@Data

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigAutoConfiguration.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigAutoConfiguration.java
@@ -40,7 +40,7 @@ public class ConsulConfigAutoConfiguration {
 		@ConditionalOnProperty(name = "spring.cloud.consul.config.watch.enabled", matchIfMissing = true)
 		public ConfigWatch configWatch(ConsulConfigProperties properties,
 				ConsulPropertySourceLocator locator, ConsulClient consul) {
-			return new ConfigWatch(properties, consul, locator.getContextIndex());
+			return new ConfigWatch(properties, consul, locator.getContextIndexes());
 		}
 	}
 }

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigAutoConfiguration.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigAutoConfiguration.java
@@ -40,7 +40,7 @@ public class ConsulConfigAutoConfiguration {
 		@ConditionalOnProperty(name = "spring.cloud.consul.config.watch.enabled", matchIfMissing = true)
 		public ConfigWatch configWatch(ConsulConfigProperties properties,
 				ConsulPropertySourceLocator locator, ConsulClient consul) {
-			return new ConfigWatch(properties, locator.getContexts(), consul);
+			return new ConfigWatch(properties, consul, locator.getContextIndex());
 		}
 	}
 }

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySource.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySource.java
@@ -48,6 +48,8 @@ public class ConsulPropertySource extends EnumerablePropertySource<ConsulClient>
 
 	private final Map<String, Object> properties = new LinkedHashMap<>();
 
+	private Long initialIndex;
+
 	public ConsulPropertySource(String context, ConsulClient source,
 			ConsulConfigProperties configProperties) {
 		super(context, source);
@@ -64,6 +66,8 @@ public class ConsulPropertySource extends EnumerablePropertySource<ConsulClient>
 		Response<List<GetValue>> response = source.getKVValues(context,
 				configProperties.getAclToken(), QueryParams.DEFAULT);
 
+		initialIndex = response.getConsulIndex();
+
 		final List<GetValue> values = response.getValue();
 		ConsulConfigProperties.Format format = configProperties.getFormat();
 		switch (format) {
@@ -74,6 +78,10 @@ public class ConsulPropertySource extends EnumerablePropertySource<ConsulClient>
 		case YAML:
 			parsePropertiesWithNonKeyValueFormat(values, format);
 		}
+	}
+
+	public Long getInitialIndex() {
+		return initialIndex;
 	}
 
 	/**

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/PropertySourcesLocatedEvent.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/PropertySourcesLocatedEvent.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.config;
+
+import org.springframework.context.ApplicationEvent;
+
+import java.util.LinkedHashMap;
+
+/**
+ * @author Spencer Gibb
+ */
+public class PropertySourcesLocatedEvent extends ApplicationEvent {
+
+	private final LinkedHashMap<String, Long> contextsToIndexes;
+
+	/**
+	 * Create a new ApplicationEvent.
+	 *
+	 * @param source the object on which the event initially occurred (never {@code null})
+	 */
+	public PropertySourcesLocatedEvent(Object source, LinkedHashMap<String, Long> contextsToIndexes) {
+		super(source);
+		this.contextsToIndexes = contextsToIndexes;
+	}
+
+	public LinkedHashMap<String, Long> getContextsToIndexes() {
+		return contextsToIndexes;
+	}
+}

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConfigWatchTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConfigWatchTests.java
@@ -109,9 +109,10 @@ public class ConfigWatchTests {
 			configProperties.setAclToken(aclToken);
 		}
 
-		ConfigWatch watch = new ConfigWatch(configProperties, consul, new LinkedHashMap<String, Long>());
+		LinkedHashMap<String, Long> initialIndexes = new LinkedHashMap<>();
+		initialIndexes.put(context, 0L);
+		ConfigWatch watch = new ConfigWatch(configProperties, consul, initialIndexes);
 		watch.setApplicationEventPublisher(eventPublisher);
-		watch.getConsulIndexes().put(context, 0L);
 		watch.start();
 
 		watch.watchConfigKeyValues();
@@ -130,7 +131,7 @@ public class ConfigWatchTests {
 		Response<List<GetValue>> response = new Response<>(getValues, 1L, false, 1L);
 		when(consul.getKVValues(eq(context), anyString(), any(QueryParams.class))).thenReturn(response);
 
-		ConfigWatch watch = new ConfigWatch(configProperties, Collections.singletonList(context), consul);
+		ConfigWatch watch = new ConfigWatch(configProperties, consul, new LinkedHashMap<String, Long>());
 		watch.setApplicationEventPublisher(eventPublisher);
 
 		watch.watchConfigKeyValues();

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConfigWatchTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConfigWatchTests.java
@@ -27,6 +27,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.util.StringUtils;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import static org.mockito.Matchers.any;
@@ -107,12 +109,32 @@ public class ConfigWatchTests {
 			configProperties.setAclToken(aclToken);
 		}
 
-		ConfigWatch watch = new ConfigWatch(configProperties, Arrays.asList(context), consul);
+		ConfigWatch watch = new ConfigWatch(configProperties, consul, new LinkedHashMap<String, Long>());
 		watch.setApplicationEventPublisher(eventPublisher);
 		watch.getConsulIndexes().put(context, 0L);
 		watch.start();
 
 		watch.watchConfigKeyValues();
+	}
+
+	@Test
+	public void firstCallDoesNotPublishEvent() {
+		ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+		configProperties.setFormat(FILES);
+
+		GetValue getValue = new GetValue();
+		String context = "/config/app.yml";
+		ConsulClient consul = mock(ConsulClient.class);
+		List<GetValue> getValues = Collections.singletonList(getValue);
+
+		Response<List<GetValue>> response = new Response<>(getValues, 1L, false, 1L);
+		when(consul.getKVValues(eq(context), anyString(), any(QueryParams.class))).thenReturn(response);
+
+		ConfigWatch watch = new ConfigWatch(configProperties, Collections.singletonList(context), consul);
+		watch.setApplicationEventPublisher(eventPublisher);
+
+		watch.watchConfigKeyValues();
+		verify(eventPublisher, times(0)).publishEvent(any(RefreshEvent.class));
 	}
 
 }


### PR DESCRIPTION
These initial indexes can then be passsed to the `ConfigWatch` so that
it doesn't have to have an odd skip the first time.

fixes gh-231
fixes gh-278