### PR TITLE
Add option to disable management registration

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
@@ -123,6 +123,9 @@ public class ConsulDiscoveryProperties {
 	/** Whether to register an http or https service */
 	private String scheme = "http";
 
+	/** Whether to register the management as a service in Consul */
+	private boolean registerManagement = true;
+
 	/** Suffix to use when registering management service */
 	private String managementSuffix = MANAGEMENT;
 

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
@@ -123,9 +123,6 @@ public class ConsulDiscoveryProperties {
 	/** Whether to register an http or https service */
 	private String scheme = "http";
 
-	/** Whether to register the management as a service in Consul */
-	private boolean registerManagement = true;
-
 	/** Suffix to use when registering management service */
 	private String managementSuffix = MANAGEMENT;
 

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulLifecycle.java
@@ -143,6 +143,11 @@ public class ConsulLifecycle extends AbstractDiscoveryLifecycle {
 		register(registration.getService());
 	}
 
+	@Override
+	protected boolean shouldRegisterManagement() {
+		return ConsulAutoRegistration.shouldRegisterManagement(properties, getContext());
+	}
+
 	protected void register(NewService newService) {
 		log.info("Registering service with consul: {}", newService.toString());
 		try {

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/TestConsulLifecycleConfiguration.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/TestConsulLifecycleConfiguration.java
@@ -20,6 +20,7 @@ import javax.servlet.ServletContext;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -39,10 +40,17 @@ public class TestConsulLifecycleConfiguration {
 	@Autowired(required = false)
 	private ServletContext servletContext;
 
+	@Autowired(required = false)
+	AutoServiceRegistrationProperties autoServiceRegistrationProperties;
+
 	@Bean
-	public ConsulLifecycle consulLifecycle(ConsulClient consulClient, ConsulDiscoveryProperties discoveryProperties,
-										   HeartbeatProperties heartbeatProperties) {
-		ConsulLifecycle lifecycle = new ConsulLifecycle(consulClient, discoveryProperties, heartbeatProperties);
+	public ConsulLifecycle consulLifecycle(ConsulClient consulClient,
+			AutoServiceRegistrationProperties autoServiceRegistrationProperties,
+			ConsulDiscoveryProperties discoveryProperties,
+			HeartbeatProperties heartbeatProperties) {
+		ConsulLifecycle lifecycle = new ConsulLifecycle(consulClient,
+				autoServiceRegistrationProperties, discoveryProperties,
+				heartbeatProperties);
 		if (this.ttlScheduler != null) {
 			lifecycle.setTtlScheduler(this.ttlScheduler);
 		}

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoRegistration.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoRegistration.java
@@ -117,15 +117,17 @@ public class ConsulAutoRegistration extends ConsulRegistration {
 
 	public static void setCheck(NewService service, ConsulDiscoveryProperties properties, ApplicationContext context, HeartbeatProperties heartbeatProperties) {
 		if (properties.isRegisterHealthCheck() && service.getCheck() == null) {
-			Integer checkPort;
-			if (shouldRegisterManagement(properties, context)) {
-				checkPort = getManagementPort(properties, context);
-			} else {
-				checkPort = service.getPort();
-			}
-			Assert.notNull(checkPort, "checkPort may not be null");
+			Integer checkPort = getCheckPort(service, properties, context);
 			service.setCheck(createCheck(checkPort, heartbeatProperties, properties));
 		}
+	}
+
+	private static Integer getCheckPort(NewService service, ConsulDiscoveryProperties properties, ApplicationContext context) {
+		Integer checkPort;
+		Integer managementPort = getManagementPort(properties, context);
+		checkPort = managementPort != null ? managementPort : service.getPort();
+		Assert.notNull(checkPort, "checkPort may not be null");
+		return checkPort;
 	}
 
 	public static ConsulAutoRegistration managementRegistration(ConsulDiscoveryProperties properties, ApplicationContext context,
@@ -234,7 +236,9 @@ public class ConsulAutoRegistration extends ConsulRegistration {
 	 * @return if the management service should be registered with the {@link ServiceRegistry}
 	 */
 	public static boolean shouldRegisterManagement(ConsulDiscoveryProperties properties, ApplicationContext context) {
-		return getManagementPort(properties, context) != null && ManagementServerPortUtils.isDifferent(context);
+		return properties.isRegisterManagement()
+				&& getManagementPort(properties, context) != null
+				&& ManagementServerPortUtils.isDifferent(context);
 	}
 
 	/**

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoRegistration.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoRegistration.java
@@ -23,6 +23,7 @@ import javax.servlet.ServletContext;
 
 import org.springframework.boot.bind.RelaxedPropertyResolver;
 import org.springframework.cloud.client.discovery.ManagementServerPortUtils;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationProperties;
 import org.springframework.cloud.client.serviceregistry.ServiceRegistry;
 import org.springframework.cloud.consul.discovery.ConsulDiscoveryProperties;
 import org.springframework.cloud.consul.discovery.HeartbeatProperties;
@@ -39,12 +40,17 @@ public class ConsulAutoRegistration extends ConsulRegistration {
 
 	public static final char SEPARATOR = '-';
 
+	private final AutoServiceRegistrationProperties autoServiceRegistrationProperties;
 	private final ConsulDiscoveryProperties properties;
 	private final ApplicationContext context;
 	private final HeartbeatProperties heartbeatProperties;
 
-	public ConsulAutoRegistration(NewService service, ConsulDiscoveryProperties properties, ApplicationContext context, HeartbeatProperties heartbeatProperties) {
+	public ConsulAutoRegistration(NewService service,
+			AutoServiceRegistrationProperties autoServiceRegistrationProperties,
+			ConsulDiscoveryProperties properties, ApplicationContext context,
+			HeartbeatProperties heartbeatProperties) {
 		super(service);
+		this.autoServiceRegistrationProperties = autoServiceRegistrationProperties;
 		this.properties = properties;
 		this.context = context;
 		this.heartbeatProperties = heartbeatProperties;
@@ -58,15 +64,19 @@ public class ConsulAutoRegistration extends ConsulRegistration {
 		// we might not have a port until now, so this is the earliest we
 		// can create a check
 
-		setCheck(getService(), this.properties, this.context, this.heartbeatProperties);
+		setCheck(getService(), this.autoServiceRegistrationProperties, this.properties,
+				this.context, this.heartbeatProperties);
 	}
 
 	public ConsulAutoRegistration managementRegistration() {
-		return managementRegistration(this.properties, this.context, this.heartbeatProperties);
+		return managementRegistration(this.autoServiceRegistrationProperties,
+				this.properties, this.context, this.heartbeatProperties);
 	}
 
-	public static ConsulAutoRegistration registration(ConsulDiscoveryProperties properties, ApplicationContext context,
-													  ServletContext servletContext, HeartbeatProperties heartbeatProperties) {
+	public static ConsulAutoRegistration registration(
+			AutoServiceRegistrationProperties autoServiceRegistrationProperties,
+			ConsulDiscoveryProperties properties, ApplicationContext context,
+			ServletContext servletContext, HeartbeatProperties heartbeatProperties) {
 		RelaxedPropertyResolver propertyResolver = new RelaxedPropertyResolver(context.getEnvironment());
 
 		NewService service = new NewService();
@@ -81,15 +91,18 @@ public class ConsulAutoRegistration extends ConsulRegistration {
 		if (properties.getPort() != null) {
 			service.setPort(properties.getPort());
 			// we know the port and can set the check
-			setCheck(service, properties, context, heartbeatProperties);
+			setCheck(service, autoServiceRegistrationProperties, properties, context, heartbeatProperties);
 		}
 
-		return new ConsulAutoRegistration(service, properties, context, heartbeatProperties);
+		return new ConsulAutoRegistration(service, autoServiceRegistrationProperties, properties, context, heartbeatProperties);
 	}
 
 	@Deprecated //TODO: do I need this here, or should I just copy what I need back into lifecycle?
-	public static ConsulAutoRegistration lifecycleRegistration(Integer port, String instanceId, ConsulDiscoveryProperties properties, ApplicationContext context,
-															   ServletContext servletContext, HeartbeatProperties heartbeatProperties) {
+	public static ConsulAutoRegistration lifecycleRegistration(Integer port,
+			String instanceId,
+			AutoServiceRegistrationProperties autoServiceRegistrationProperties,
+			ConsulDiscoveryProperties properties, ApplicationContext context,
+			ServletContext servletContext, HeartbeatProperties heartbeatProperties) {
 		RelaxedPropertyResolver propertyResolver = new RelaxedPropertyResolver(context.getEnvironment());
 
 		NewService service = new NewService();
@@ -110,28 +123,31 @@ public class ConsulAutoRegistration extends ConsulRegistration {
 
 		Assert.notNull(service.getPort(), "service.port may not be null");
 
-		setCheck(service, properties, context, heartbeatProperties);
+		setCheck(service, autoServiceRegistrationProperties, properties, context, heartbeatProperties);
 
-		return new ConsulAutoRegistration(service, properties, context, heartbeatProperties);
+		return new ConsulAutoRegistration(service, autoServiceRegistrationProperties, properties, context, heartbeatProperties);
 	}
 
-	public static void setCheck(NewService service, ConsulDiscoveryProperties properties, ApplicationContext context, HeartbeatProperties heartbeatProperties) {
+	public static void setCheck(NewService service,
+			AutoServiceRegistrationProperties autoServiceRegistrationProperties,
+			ConsulDiscoveryProperties properties, ApplicationContext context,
+			HeartbeatProperties heartbeatProperties) {
 		if (properties.isRegisterHealthCheck() && service.getCheck() == null) {
-			Integer checkPort = getCheckPort(service, properties, context);
+			Integer checkPort;
+			if (shouldRegisterManagement(autoServiceRegistrationProperties, properties, context)) {
+				checkPort = getManagementPort(properties, context);
+			} else {
+				checkPort = service.getPort();
+			}
+			Assert.notNull(checkPort, "checkPort may not be null");
 			service.setCheck(createCheck(checkPort, heartbeatProperties, properties));
 		}
 	}
 
-	private static Integer getCheckPort(NewService service, ConsulDiscoveryProperties properties, ApplicationContext context) {
-		Integer checkPort;
-		Integer managementPort = getManagementPort(properties, context);
-		checkPort = managementPort != null ? managementPort : service.getPort();
-		Assert.notNull(checkPort, "checkPort may not be null");
-		return checkPort;
-	}
-
-	public static ConsulAutoRegistration managementRegistration(ConsulDiscoveryProperties properties, ApplicationContext context,
-																HeartbeatProperties heartbeatProperties) {
+	public static ConsulAutoRegistration managementRegistration(
+			AutoServiceRegistrationProperties autoServiceRegistrationProperties,
+			ConsulDiscoveryProperties properties, ApplicationContext context,
+			HeartbeatProperties heartbeatProperties) {
 		RelaxedPropertyResolver propertyResolver = new RelaxedPropertyResolver(context.getEnvironment());
 		NewService management = new NewService();
 		management.setId(getManagementServiceId(properties, context));
@@ -142,7 +158,7 @@ public class ConsulAutoRegistration extends ConsulRegistration {
 		if (properties.isRegisterHealthCheck()) {
 			management.setCheck(createCheck(getManagementPort(properties, context), heartbeatProperties, properties));
 		}
-		return new ConsulAutoRegistration(management, properties, context, heartbeatProperties);
+		return new ConsulAutoRegistration(management, autoServiceRegistrationProperties, properties, context, heartbeatProperties);
 	}
 
 	public static String getInstanceId(ConsulDiscoveryProperties properties, ApplicationContext context) {
@@ -235,9 +251,11 @@ public class ConsulAutoRegistration extends ConsulRegistration {
 	/**
 	 * @return if the management service should be registered with the {@link ServiceRegistry}
 	 */
-	public static boolean shouldRegisterManagement(ConsulDiscoveryProperties properties, ApplicationContext context) {
-		return properties.isRegisterManagement()
-				&& getManagementPort(properties, context) != null
+	public static boolean shouldRegisterManagement(AutoServiceRegistrationProperties autoServiceRegistrationProperties, ConsulDiscoveryProperties properties, ApplicationContext context) {
+		return
+				//autoServiceRegistrationProperties.isRegisterManagement()
+				//&& getManagementPort(properties, context) != null
+				     getManagementPort(properties, context) != null
 				&& ManagementServerPortUtils.isDifferent(context);
 	}
 

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistration.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistration.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.consul.serviceregistry;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.client.serviceregistry.AbstractAutoServiceRegistration;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationProperties;
 import org.springframework.cloud.consul.discovery.ConsulDiscoveryProperties;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.util.Assert;
@@ -31,12 +32,15 @@ public class ConsulAutoServiceRegistration extends AbstractAutoServiceRegistrati
 
 	private static Log log = LogFactory.getLog(ConsulAutoServiceRegistration.class);
 
+	private AutoServiceRegistrationProperties autoServiceRegistrationProperties;
 	private ConsulDiscoveryProperties properties;
 	private ConsulAutoRegistration registration;
 
-	public ConsulAutoServiceRegistration(ConsulServiceRegistry serviceRegistry, ConsulDiscoveryProperties properties,
-										 ConsulAutoRegistration registration) {
+	public ConsulAutoServiceRegistration(ConsulServiceRegistry serviceRegistry,
+			AutoServiceRegistrationProperties autoServiceRegistrationProperties,
+			ConsulDiscoveryProperties properties, ConsulAutoRegistration registration) {
 		super(serviceRegistry);
+		this.autoServiceRegistrationProperties = autoServiceRegistrationProperties;
 		this.properties = properties;
 		this.registration = registration;
 	}
@@ -84,7 +88,8 @@ public class ConsulAutoServiceRegistration extends AbstractAutoServiceRegistrati
 
 	@Override
 	protected boolean shouldRegisterManagement() {
-		return ConsulAutoRegistration.shouldRegisterManagement(properties, getContext());
+		return ConsulAutoRegistration.shouldRegisterManagement(
+				autoServiceRegistrationProperties, properties, getContext());
 	}
 
 	@Override

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistration.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistration.java
@@ -82,6 +82,10 @@ public class ConsulAutoServiceRegistration extends AbstractAutoServiceRegistrati
 		super.register();
 	}
 
+	@Override
+	protected boolean shouldRegisterManagement() {
+		return ConsulAutoRegistration.shouldRegisterManagement(properties, getContext());
+	}
 
 	@Override
 	protected void registerManagement() {

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationAutoConfiguration.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationAutoConfiguration.java
@@ -18,10 +18,13 @@ package org.springframework.cloud.consul.serviceregistry;
 
 import javax.servlet.ServletContext;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationAutoConfiguration;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationProperties;
 import org.springframework.cloud.consul.ConditionalOnConsulEnabled;
 import org.springframework.cloud.consul.discovery.ConsulDiscoveryProperties;
@@ -38,20 +41,31 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnMissingBean(type = "org.springframework.cloud.consul.discovery.ConsulLifecycle")
 @ConditionalOnConsulEnabled
 @ConditionalOnProperty(value = "spring.cloud.service-registry.auto-registration.enabled", matchIfMissing = true)
-@AutoConfigureAfter(ConsulServiceRegistryAutoConfiguration.class)
+@AutoConfigureAfter({AutoServiceRegistrationConfiguration.class, ConsulServiceRegistryAutoConfiguration.class})
 public class ConsulAutoServiceRegistrationAutoConfiguration {
+
+	@Autowired
+	AutoServiceRegistrationProperties autoServiceRegistrationProperties;
 
 	@Bean
 	@ConditionalOnMissingBean
-	public ConsulAutoServiceRegistration consulAutoServiceRegistration(ConsulServiceRegistry registry, ConsulDiscoveryProperties properties, ConsulAutoRegistration consulRegistration) {
-		return new ConsulAutoServiceRegistration(registry, properties, consulRegistration);
+	public ConsulAutoServiceRegistration consulAutoServiceRegistration(
+			ConsulServiceRegistry registry,
+			AutoServiceRegistrationProperties autoServiceRegistrationProperties,
+			ConsulDiscoveryProperties properties,
+			ConsulAutoRegistration consulRegistration) {
+		return new ConsulAutoServiceRegistration(registry,
+				autoServiceRegistrationProperties, properties, consulRegistration);
 	}
 
 	@Bean
 	@ConditionalOnMissingBean
-	public ConsulAutoRegistration consulRegistration(ConsulDiscoveryProperties properties, ApplicationContext applicationContext,
-												 ServletContext servletContext, HeartbeatProperties heartbeatProperties) {
-		return ConsulAutoRegistration.registration(properties, applicationContext, servletContext, heartbeatProperties);
+	public ConsulAutoRegistration consulRegistration(
+			AutoServiceRegistrationProperties autoServiceRegistrationProperties,
+			ConsulDiscoveryProperties properties, ApplicationContext applicationContext,
+			ServletContext servletContext, HeartbeatProperties heartbeatProperties) {
+		return ConsulAutoRegistration.registration(autoServiceRegistrationProperties,
+				properties, applicationContext, servletContext, heartbeatProperties);
 	}
 
 }

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedPropsTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedPropsTests.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
 import org.springframework.cloud.consul.ConsulAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -94,7 +95,9 @@ public class ConsulLifecycleCustomizedPropsTests {
 
 @Configuration
 @EnableAutoConfiguration
-@ImportAutoConfiguration({ TestConsulLifecycleConfiguration.class, ConsulAutoConfiguration.class, ConsulDiscoveryClientConfiguration.class })
+@ImportAutoConfiguration({ AutoServiceRegistrationConfiguration.class,
+		TestConsulLifecycleConfiguration.class, ConsulAutoConfiguration.class,
+		ConsulDiscoveryClientConfiguration.class })
 class TestPropsConfig {
 
 }

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleCustomizedTests.java
@@ -25,6 +25,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -54,6 +55,8 @@ public class ConsulLifecycleCustomizedTests {
 	@Autowired
 	private CustomConsulLifecycle lifecycle2;
 	@Autowired
+	AutoServiceRegistrationProperties autoServiceRegistrationProperties;
+	@Autowired
 	private ConsulDiscoveryProperties properties;
 
 	@Test
@@ -82,8 +85,10 @@ public class ConsulLifecycleCustomizedTests {
 	public static class MyTestConfig {
 		@Bean
 		public ConsulLifecycle customizedLifecycle(ConsulClient client,
+				AutoServiceRegistrationProperties autoServiceRegistrationProperties,
 				ConsulDiscoveryProperties properties, HeartbeatProperties ttlConfig) {
-			return new CustomConsulLifecycle(client, properties, ttlConfig);
+			return new CustomConsulLifecycle(client, autoServiceRegistrationProperties,
+					properties, ttlConfig);
 		}
 	}
 
@@ -92,8 +97,9 @@ public class ConsulLifecycleCustomizedTests {
 
 		@Autowired
 		public CustomConsulLifecycle(ConsulClient client,
+				AutoServiceRegistrationProperties autoServiceRegistrationProperties,
 				ConsulDiscoveryProperties properties, HeartbeatProperties ttlConfig) {
-			super(client, properties, ttlConfig);
+			super(client, autoServiceRegistrationProperties, properties, ttlConfig);
 			this.properties = properties;
 		}
 

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulLifecycleTests.java
@@ -25,6 +25,7 @@ import org.junit.runners.MethodSorters;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
 import org.springframework.cloud.consul.ConsulAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -110,7 +111,9 @@ public class ConsulLifecycleTests {
 
 @Configuration
 @EnableAutoConfiguration
-@Import({ TestConsulLifecycleConfiguration.class, ConsulAutoConfiguration.class, ConsulDiscoveryClientConfiguration.class })
+@Import({ AutoServiceRegistrationConfiguration.class,
+		TestConsulLifecycleConfiguration.class, ConsulAutoConfiguration.class,
+		ConsulDiscoveryClientConfiguration.class })
 class TestConfig {
 
 }

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/TtlSchedulerRemoveTest.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/TtlSchedulerRemoveTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
 import org.springframework.cloud.consul.ConsulAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -69,7 +70,9 @@ public class TtlSchedulerRemoveTest {
 	@Configuration
 	@EnableDiscoveryClient(autoRegister = false) //FIXME: this is weird because we're testing the deprecated lifecycle, not autoconfiguration
 	@EnableAutoConfiguration
-	@ImportAutoConfiguration({ TestConsulLifecycleConfiguration.class, ConsulAutoConfiguration.class, ConsulDiscoveryClientConfiguration.class })
+	@ImportAutoConfiguration({ AutoServiceRegistrationConfiguration.class,
+			TestConsulLifecycleConfiguration.class, ConsulAutoConfiguration.class,
+			ConsulDiscoveryClientConfiguration.class })
 	public static class TtlSchedulerRemoveTestConfig { }
 }
 

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/TtlSchedulerTest.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/TtlSchedulerTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
 import org.springframework.cloud.consul.ConsulAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -63,7 +64,9 @@ public class TtlSchedulerTest {
 	@Configuration
 	@EnableDiscoveryClient(autoRegister = false) //FIXME:
 	@EnableAutoConfiguration
-	@ImportAutoConfiguration({ TestConsulLifecycleConfiguration.class, ConsulAutoConfiguration.class, ConsulDiscoveryClientConfiguration.class })
+	@ImportAutoConfiguration({ AutoServiceRegistrationConfiguration.class,
+			TestConsulLifecycleConfiguration.class, ConsulAutoConfiguration.class,
+			ConsulDiscoveryClientConfiguration.class })
 	public static class TtlSchedulerTestConfig { }
 }
 

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationCustomizedTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationCustomizedTests.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationProperties;
 import org.springframework.cloud.consul.ConsulAutoConfiguration;
 import org.springframework.cloud.consul.discovery.ConsulDiscoveryProperties;
 import org.springframework.context.annotation.Bean;
@@ -42,6 +43,9 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 public class ConsulAutoServiceRegistrationCustomizedTests {
 
 	@Autowired
+	private AutoServiceRegistrationProperties autoServiceRegistrationProperties;
+
+	@Autowired
 	private ConsulAutoServiceRegistration registration1;
 
 	@Autowired
@@ -58,18 +62,25 @@ public class ConsulAutoServiceRegistrationCustomizedTests {
 	@ImportAutoConfiguration({ AutoServiceRegistrationConfiguration.class, ConsulAutoConfiguration.class, ConsulAutoServiceRegistrationAutoConfiguration.class })
 	public static class MyTestConfig {
 		@Bean
-		public CustomAutoRegistration consulAutoServiceRegistration(ConsulServiceRegistry serviceRegistry, ConsulDiscoveryProperties properties,
-																	ConsulAutoRegistration registration) {
-			return new CustomAutoRegistration(serviceRegistry, properties, registration);
+		public CustomAutoRegistration consulAutoServiceRegistration(
+				ConsulServiceRegistry serviceRegistry,
+				AutoServiceRegistrationProperties autoServiceRegistrationProperties,
+				ConsulDiscoveryProperties properties,
+				ConsulAutoRegistration registration) {
+			return new CustomAutoRegistration(serviceRegistry,
+					autoServiceRegistrationProperties, properties, registration);
 		}
 	}
 
 	public static class CustomAutoRegistration extends ConsulAutoServiceRegistration {
 
 		@Autowired
-		public CustomAutoRegistration(ConsulServiceRegistry serviceRegistry, ConsulDiscoveryProperties properties,
-									  ConsulAutoRegistration registration) {
-			super(serviceRegistry, properties, registration);
+		public CustomAutoRegistration(ConsulServiceRegistry serviceRegistry,
+				AutoServiceRegistrationProperties autoServiceRegistrationProperties,
+				ConsulDiscoveryProperties properties,
+				ConsulAutoRegistration registration) {
+			super(serviceRegistry, autoServiceRegistrationProperties, properties,
+					registration);
 		}
 
 		@Override

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationManagementDisabledServiceTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationManagementDisabledServiceTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.serviceregistry;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.Response;
+import com.ecwid.consul.v1.agent.model.Service;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
+import org.springframework.cloud.consul.ConsulAutoConfiguration;
+import org.springframework.cloud.consul.discovery.ConsulDiscoveryProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.StringUtils;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * @author Dmitry Zhikharev (jihor)
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = ConsulAutoServiceRegistrationManagementDisabledServiceTests.TestConfig.class,
+        properties = {"spring.application.name=myTestService-NM",
+                "spring.cloud.consul.discovery.instanceId=myTestService1-NM",
+                "spring.cloud.consul.discovery.registerManagement=false",
+                "spring.cloud.consul.discovery.managementPort=4453",
+                "management.port=0" },
+        webEnvironment = RANDOM_PORT)
+public class ConsulAutoServiceRegistrationManagementDisabledServiceTests {
+
+    @Autowired
+    private ConsulClient consul;
+
+    @Autowired
+    private ConsulDiscoveryProperties discoveryProperties;
+
+    @Test
+    public void contextLoads() {
+        Response<Map<String, Service>> response = consul.getAgentServices();
+        Map<String, Service> services = response.getValue();
+
+        Service mgmtService = services.get("myTestService-NM-0-management");
+        assertNull("Management service was not null", mgmtService);
+
+        Service service = services.get("myTestService1-NM");
+        assertNotNull("Service was not null", service);
+        assertNotEquals("service port was 0", 0, service.getPort().intValue());
+        assertEquals("service id was wrong", "myTestService1-NM", service.getId());
+        assertEquals("service name was wrong", "myTestService-NM", service.getService());
+        assertFalse("service address must not be empty", StringUtils.isEmpty(service.getAddress()));
+        assertEquals("service address must equals hostname from discovery properties", discoveryProperties.getHostname(), service.getAddress());
+
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    @ImportAutoConfiguration({AutoServiceRegistrationConfiguration.class,
+            ConsulAutoConfiguration.class,
+            ConsulAutoServiceRegistrationAutoConfiguration.class})
+    public static class TestConfig {}
+}

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationManagementDisabledServiceTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationManagementDisabledServiceTests.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.consul.serviceregistry;
 import com.ecwid.consul.v1.ConsulClient;
 import com.ecwid.consul.v1.Response;
 import com.ecwid.consul.v1.agent.model.Service;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,6 +61,10 @@ public class ConsulAutoServiceRegistrationManagementDisabledServiceTests {
     @Autowired
     private ConsulDiscoveryProperties discoveryProperties;
 
+    @Ignore("Can be enabled after " +
+            "org.springframework.cloud.consul.serviceregistry.ConsulAutoRegistration.shouldRegisterManagement() " +
+            "will start taking autoServiceRegistrationProperties.isRegisterManagement() into account. " +
+            "See https://github.com/spring-cloud/spring-cloud-commons/pull/221")
     @Test
     public void contextLoads() {
         Response<Map<String, Service>> response = consul.getAgentServices();

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationWithLifecycleTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationWithLifecycleTests.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationProperties;
 import org.springframework.cloud.consul.ConsulAutoConfiguration;
 import org.springframework.cloud.consul.discovery.ConsulDiscoveryProperties;
 import org.springframework.cloud.consul.discovery.ConsulLifecycle;
@@ -54,6 +55,9 @@ public class ConsulAutoServiceRegistrationWithLifecycleTests {
 	@Autowired(required = false)
 	private ConsulServiceRegistry consulServiceRegistry;
 
+	@Autowired(required = false)
+	private AutoServiceRegistrationProperties autoServiceRegistrationProperties;
+
 	@Test
 	public void contextLoads() {
 		assertNull("consulRegistration was created by mistake", consulRegistration);
@@ -66,8 +70,12 @@ public class ConsulAutoServiceRegistrationWithLifecycleTests {
 	@ImportAutoConfiguration({ AutoServiceRegistrationConfiguration.class, ConsulAutoConfiguration.class, ConsulAutoServiceRegistrationAutoConfiguration.class })
 	protected static class TestConfig {
 		@Bean
-		public ConsulLifecycle consulLifecycle(ConsulClient client, ConsulDiscoveryProperties properties, HeartbeatProperties heartbeatProperties) {
-			return new ConsulLifecycle(client, properties, heartbeatProperties);
+		public ConsulLifecycle consulLifecycle(ConsulClient client,
+				AutoServiceRegistrationProperties autoServiceRegistrationProperties,
+				ConsulDiscoveryProperties properties,
+				HeartbeatProperties heartbeatProperties) {
+			return new ConsulLifecycle(client, autoServiceRegistrationProperties,
+					properties, heartbeatProperties);
 		}
 	}
 }


### PR DESCRIPTION
I've added `spring.cloud.consul.discovery.registerManagement` option to avoid registering management as a separate service. The default behavior is not changed.