### PR TITLE
Remove misleading statement about not supporting config watch

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-consul.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-consul.adoc
@@ -152,7 +152,7 @@ config/application/
 
 The most specific property source is at the top, with the least specific at the bottom.  Properties in the `config/application` folder are applicable to all applications using consul for configuration.  Properties in the `config/testApp` folder are only available to the instances of the service named "testApp".
 
-Configuration is currently read on startup of the application.  Sending a HTTP POST to `/refresh` will cause the configuration to be reloaded.  Watching the key value store (which Consul supports) is not currently possible, but will be a future addition to this project.
+Configuration is currently read on startup of the application.  Sending a HTTP POST to `/refresh` will cause the configuration to be reloaded. <<spring-cloud-consul-config-watch>> will also automatically detect changes and reload the application context.
 
 === How to activate
 


### PR DESCRIPTION
Removes the misleading statement that it's not supported and adds a reference to the Config Watch section.

Fixes #343