### PR TITLE
Fix ConsulHealthIndicator to stop reading internal config values

### DIFF
--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulHealthIndicator.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulHealthIndicator.java
@@ -41,19 +41,13 @@ public class ConsulHealthIndicator extends AbstractHealthIndicator {
 
 	@Override
 	protected void doHealthCheck(Health.Builder builder) throws Exception {
-		try {
-			Response<Self> self = consul.getAgentSelf();
-			Config config = self.getValue().getConfig();
+		try {  
+			Response<String> leaderStatus = consul.getStatusLeader();
 			Response<Map<String, List<String>>> services = consul
 					.getCatalogServices(QueryParams.DEFAULT);
 			builder.up()
-					.withDetail("services", services.getValue())
-					.withDetail("advertiseAddress", config.getAdvertiseAddress())
-					.withDetail("datacenter", config.getDatacenter())
-					.withDetail("domain", config.getDomain())
-					.withDetail("nodeName", config.getNodeName())
-					.withDetail("bindAddress", config.getBindAddress())
-					.withDetail("clientAddress", config.getClientAddress());
+                                       .withDetail("leader", leaderStatus.getValue())
+					.withDetail("services", services.getValue());
 		}
 		catch (Exception e) {
 			builder.down(e);


### PR DESCRIPTION
and switch to a more stable API status/leader that is a recommended way to test for Consul availability.

Note that there are still underlying incompatibilities with ecwid/Consul 1.0 documented in https://github.com/Ecwid/consul-api/issues/130. For instance, [service deregistration](https://github.com/Ecwid/consul-api/blob/master/src/main/java/com/ecwid/consul/v1/agent/AgentConsulClient.java#L263) does a GET even though [the documentation](https://www.consul.io/api/agent/service.html#deregister-service)  specifies it should be PUT. Consul 1.0 will enforce this and return a 403.