### PR TITLE
Optional Prefix

### DIFF
--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
@@ -35,7 +35,6 @@ import lombok.Data;
 public class ConsulConfigProperties {
 	private boolean enabled = true;
 
-	@NotEmpty
 	private String prefix = "config";
 
 	@NotEmpty

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocator.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocator.java
@@ -96,7 +96,14 @@ public class ConsulPropertySourceLocator implements PropertySourceLocator {
 				suffixes.add(".properties");
 			}
 
-			String defaultContext = prefix + "/" + this.properties.getDefaultContext();
+			String defaultContext;
+			if (prefix == null || prefix.isEmpty()) {
+				defaultContext = this.properties.getDefaultContext();
+			}
+			else {
+				defaultContext = prefix + "/" + this.properties.getDefaultContext();
+			}
+
 			for (String suffix : suffixes) {
 				this.contexts.add(defaultContext + suffix);
 			}
@@ -104,7 +111,14 @@ public class ConsulPropertySourceLocator implements PropertySourceLocator {
 				addProfiles(this.contexts, defaultContext, profiles, suffix);
 			}
 
-			String baseContext = prefix + "/" + appName;
+			String baseContext;
+			if (prefix == null || prefix.isEmpty()) {
+				baseContext = appName;
+			}
+			else {
+				baseContext = prefix + "/" + appName;
+			}
+
 			for (String suffix : suffixes) {
 				this.contexts.add(baseContext + suffix);
 			}

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulPropertyPrefixTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulPropertyPrefixTests.java
@@ -1,0 +1,57 @@
+package org.springframework.cloud.consul.config;
+
+import com.ecwid.consul.v1.ConsulClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.cloud.consul.ConsulProperties;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class ConsulPropertyPrefixTests {
+
+	private ConsulClient client;
+	private ConsulProperties properties;
+	private String prefix;
+	private String kvContext;
+
+	@Before
+	public void setup() {
+		properties = new ConsulProperties();
+		prefix = "";
+		client = new ConsulClient(properties.getHost(), properties.getPort());
+	}
+
+	@After
+	public void teardown() {
+		client.deleteKVValues(prefix);
+	}
+
+	@Test
+	public void testEmptyPrefix() {
+		// because prefix is empty, a leading forward slash is omitted
+		kvContext = "appname";
+		client.setKVValue(kvContext + "/fooprop", "fookvval");
+		client.setKVValue(kvContext + "/bar/prop", "8080");
+
+		ConsulPropertySource source = getConsulPropertySource(new ConsulConfigProperties(), kvContext);
+		assertProperties(source, "fookvval", "8080");
+	}
+
+	private void assertProperties(ConsulPropertySource source, Object fooval, Object barval) {
+		assertThat("fooprop was wrong", source.getProperty("fooprop"), is(equalTo(fooval)));
+		assertThat("bar.prop was wrong", source.getProperty("bar.prop"), is(equalTo(barval)));
+	}
+
+	private ConsulPropertySource getConsulPropertySource(ConsulConfigProperties configProperties, String context) {
+		ConsulPropertySource source = new ConsulPropertySource(context, client, configProperties);
+		source.init();
+		String[] names = source.getPropertyNames();
+		assertThat("names was null", names, is(notNullValue()));
+		assertThat("names was wrong size", names.length, is(equalTo(2)));
+		return source;
+	}
+}


### PR DESCRIPTION
Makes a prefix optional.
If prefix is empty, then it will fall back on `${spring.application.name}`

Closes: https://github.com/spring-cloud/spring-cloud-consul/issues/308