### PR TITLE
Add config for consul schema

### DIFF
--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulAutoConfiguration.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.retry.interceptor.RetryInterceptorBuilder;
 import org.springframework.retry.interceptor.RetryOperationsInterceptor;
 
 import com.ecwid.consul.v1.ConsulClient;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Spencer Gibb
@@ -51,7 +52,12 @@ public class ConsulAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public ConsulClient consulClient(ConsulProperties consulProperties) {
-		return new ConsulClient(consulProperties.getHost(), consulProperties.getPort());
+                final int agentPort = consulProperties.getPort();
+                final String agentHost = !StringUtils.isEmpty(consulProperties.getScheme())
+                        ? consulProperties.getScheme() + "://" + consulProperties.getHost()
+                        : consulProperties.getHost();
+
+		return new ConsulClient(agentHost, agentPort);
 	}
 
 	@Configuration

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulProperties.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulProperties.java
@@ -31,6 +31,12 @@ public class ConsulProperties {
 	@NotNull
 	private String host = "localhost";
 
+	/**
+         * Consul agent scheme (HTTP/HTTPS).
+         * If there is no scheme in address - client will use HTTP.
+         */
+	private String scheme;
+
 	/** Consul agent port. Defaults to '8500'. */
 	@NotNull
 	private int port = 8500;
@@ -62,11 +68,20 @@ public class ConsulProperties {
 		this.enabled = enabled;
 	}
 
+        public String getScheme() {
+		return scheme;
+        }
+
+        public void setScheme(String scheme) {
+		this.scheme = scheme;
+        }
+
 	@Override
 	public String toString() {
 		return "ConsulProperties{" +
 				"host='" + host + '\'' +
 				", port=" + port +
+				", scheme=" + scheme +
 				", enabled=" + enabled +
 				'}';
 	}


### PR DESCRIPTION
This allow for you to specify scheme (HTTP/HTTPS) in the address via `spring.cloud.consul.schema`.

`com.ecwid.consul:consul-api` supports this as part of the [agent host](https://github.com/Ecwid/consul-api/blob/master/src/main/java/com/ecwid/consul/v1/ConsulClient.java#L134-L136)