### PR TITLE
Apply customized instanceId and serviceName to management service

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-consul.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-consul.adoc
@@ -76,6 +76,83 @@ To disable the Consul Discovery Client you can set `spring.cloud.consul.discover
 
 To disable the service registration you can set `spring.cloud.consul.discovery.register` to `false`.
 
+==== Registering Management as a Separate Service
+
+When management server port is set to something different than the application port, by setting `management.server.port` property, management service will be registered as a separate service than the application service. For example:
+
+.application.yml
+----
+spring:
+  application:
+    name: myApp
+management:
+  server:
+    port: 4452
+----
+
+Above configuration will register following 2 services:
+
+* Application Service:
+
+----
+ID: myApp
+Name: myApp
+----
+
+* Management Service:
+
+----
+ID: myApp-management
+Name: myApp-management
+----
+
+Management service will inherit its `instanceId` and `serviceName` from the application service. For example:
+
+.application.yml
+----
+spring:
+  application:
+    name: myApp
+management:
+  server:
+    port: 4452
+spring:
+  cloud:
+    consul:
+      discovery:
+        instance-id: custom-service-id
+        serviceName: myprefix-${spring.application.name}
+----
+
+Above configuration will register following 2 services:
+
+* Application Service:
+
+----
+ID: custom-service-id
+Name: myprefix-myApp
+----
+
+* Management Service:
+
+----
+ID: custom-service-id-management
+Name: myprefix-myApp-management
+----
+
+Further customization is possible via following properties:
+
+----
+/** Port to register the management service under (defaults to management port) */
+spring.cloud.consul.discovery.management-port
+
+/** Suffix to use when registering management service (defaults to "management" */
+spring.cloud.consul.discovery.management-suffix
+
+/** Tags to use when registering management service (defaults to "management" */
+spring.cloud.consul.discovery.management-tags
+----
+
 === HTTP Health Check
 
 The health check for a Consul instance defaults to "/health", which is the default locations of a useful endpoint in a Spring Boot Actuator application. You need to change these, even for an Actuator application if you use a non-default context path or servlet path (e.g. `server.servletPath=/foo`) or management endpoint path (e.g. `management.server.servlet.context-path=/admin`). The interval that Consul uses to check the health endpoint may also be configured.  "10s" and "1m" represent 10 seconds and 1 minute respectively.  Example:

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoRegistration.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoRegistration.java
@@ -137,9 +137,8 @@ public class ConsulAutoRegistration extends ConsulRegistration {
 	public static String getInstanceId(ConsulDiscoveryProperties properties, ApplicationContext context) {
 		if (!StringUtils.hasText(properties.getInstanceId())) {
 			return normalizeForDns(IdUtils.getDefaultInstanceId(context.getEnvironment(), false));
-		} else {
-			return normalizeForDns(properties.getInstanceId());
 		}
+		return normalizeForDns(properties.getInstanceId());
 	}
 
 	public static String normalizeForDns(String s) {
@@ -214,8 +213,8 @@ public class ConsulAutoRegistration extends ConsulRegistration {
 	 * @return the app name, currently the spring.application.name property
 	 */
 	public static String getAppName(ConsulDiscoveryProperties properties, Environment env) {
-		String appName = properties.getServiceName();
-		if (!StringUtils.isEmpty(appName)) {
+		final String appName = properties.getServiceName();
+		if (StringUtils.hasText(appName)) {
 			return appName;
 		}
 		return env.getProperty("spring.application.name", "application");
@@ -234,6 +233,10 @@ public class ConsulAutoRegistration extends ConsulRegistration {
 	 * @return the serviceId of the Management Service
 	 */
 	public static String getManagementServiceId(ConsulDiscoveryProperties properties, ApplicationContext context) {
+		final String instanceId = properties.getInstanceId();
+		if (StringUtils.hasText(instanceId)) {
+			return normalizeForDns(instanceId + SEPARATOR + properties.getManagementSuffix());
+		}
 		return normalizeForDns(IdUtils.getDefaultInstanceId(context.getEnvironment(), false)) + SEPARATOR + properties.getManagementSuffix();
 	}
 
@@ -241,6 +244,10 @@ public class ConsulAutoRegistration extends ConsulRegistration {
 	 * @return the service name of the Management Service
 	 */
 	public static String getManagementServiceName(ConsulDiscoveryProperties properties, Environment env) {
+		final String appName = properties.getServiceName();
+		if (StringUtils.hasText(appName)) {
+			return normalizeForDns(appName + SEPARATOR + properties.getManagementSuffix());
+		}
 		return normalizeForDns(getAppName(properties, env)) + SEPARATOR + properties.getManagementSuffix();
 	}
 

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationCustomizedManagementServicePortTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationCustomizedManagementServicePortTests.java
@@ -16,7 +16,10 @@
 
 package org.springframework.cloud.consul.serviceregistry;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 import java.util.Map;
@@ -72,7 +75,8 @@ public class ConsulAutoServiceRegistrationCustomizedManagementServicePortTests {
 		assertNotNull("service was null", service);
 		assertNotEquals("service port was 0", 0, service.getPort().intValue());
 		assertEquals("service id was wrong", "myTestService1-GG", service.getId());
-		assertEquals("service name was wrong", "myprefix-myTestService-GG", service.getService());
+		assertEquals("service name was wrong", "myprefix-myTestService-GG",
+				service.getService());
 		assertFalse("service address must not be empty",
 				StringUtils.isEmpty(service.getAddress()));
 		assertEquals("service address must equals hostname from discovery properties",
@@ -86,8 +90,8 @@ public class ConsulAutoServiceRegistrationCustomizedManagementServicePortTests {
 				managementServerProperties.getPort().intValue());
 		assertEquals("management service id was wrong", "myTestService1-GG-management",
 				managementService.getId());
-		assertEquals("management service name was wrong", "myprefix-myTestService-GG-management",
-				managementService.getService());
+		assertEquals("management service name was wrong",
+				"myprefix-myTestService-GG-management", managementService.getService());
 		assertFalse("management service address must not be empty",
 				StringUtils.isEmpty(managementService.getAddress()));
 		assertEquals(

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationCustomizedManagementServicePortTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationCustomizedManagementServicePortTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.consul.serviceregistry;
 
+import static org.junit.Assert.*;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
 import java.util.Map;
 
 import org.junit.Test;
@@ -36,22 +39,19 @@ import com.ecwid.consul.v1.ConsulClient;
 import com.ecwid.consul.v1.Response;
 import com.ecwid.consul.v1.agent.model.Service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-
 /**
  * @author Aleksandr Tarasov (aatarasov)
  * @author Alex Antonov (aantonov)
+ * @author Lomesh Patel (lomeshpatel)
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = ConsulAutoServiceRegistrationCustomizedManagementServicePortTests.TestConfig.class,
-	properties = {"spring.application.name=myTestService-GG",
+@SpringBootTest(classes = ConsulAutoServiceRegistrationCustomizedManagementServicePortTests.TestConfig.class, properties = {
+		"spring.application.name=myTestService-GG",
 		"spring.cloud.consul.discovery.instanceId=myTestService1-GG",
 		"spring.cloud.consul.discovery.registerHealthCheck=false",
-		"spring.cloud.consul.discovery.managementPort=4452", "management.server.port=0"},
-		webEnvironment = RANDOM_PORT)
+		"spring.cloud.consul.discovery.managementPort=4452",
+		"spring.cloud.consul.discovery.serviceName=myprefix-${spring.application.name}",
+		"management.server.port=0" }, webEnvironment = RANDOM_PORT)
 public class ConsulAutoServiceRegistrationCustomizedManagementServicePortTests {
 
 	@Autowired
@@ -65,20 +65,41 @@ public class ConsulAutoServiceRegistrationCustomizedManagementServicePortTests {
 
 	@Test
 	public void contextLoads() {
-		Response<Map<String, Service>> response = consul.getAgentServices();
-		Map<String, Service> services = response.getValue();
-		Service service = services.get("myTestService-GG-0-management");
+		final Response<Map<String, Service>> response = consul.getAgentServices();
+		final Map<String, Service> services = response.getValue();
+
+		final Service service = services.get("myTestService1-GG");
 		assertNotNull("service was null", service);
-		assertEquals("service port is not 4452", 4452, service.getPort().intValue());
-		assertEquals("management port is not 0", 0, managementServerProperties.getPort().intValue());
-		assertEquals("service id was wrong", "myTestService-GG-0-management", service.getId());
-		assertEquals("service name was wrong", "myTestService-GG-management", service.getService());
-		assertFalse("service address must not be empty", StringUtils.isEmpty(service.getAddress()));
-		assertEquals("service address must equals hostname from discovery properties", discoveryProperties.getHostname(), service.getAddress());
+		assertNotEquals("service port was 0", 0, service.getPort().intValue());
+		assertEquals("service id was wrong", "myTestService1-GG", service.getId());
+		assertEquals("service name was wrong", "myprefix-myTestService-GG", service.getService());
+		assertFalse("service address must not be empty",
+				StringUtils.isEmpty(service.getAddress()));
+		assertEquals("service address must equals hostname from discovery properties",
+				discoveryProperties.getHostname(), service.getAddress());
+
+		final Service managementService = services.get("myTestService1-GG-management");
+		assertNotNull("management service was null", managementService);
+		assertEquals("management service port is not 4452", 4452,
+				managementService.getPort().intValue());
+		assertEquals("management port is not 0", 0,
+				managementServerProperties.getPort().intValue());
+		assertEquals("management service id was wrong", "myTestService1-GG-management",
+				managementService.getId());
+		assertEquals("management service name was wrong", "myprefix-myTestService-GG-management",
+				managementService.getService());
+		assertFalse("management service address must not be empty",
+				StringUtils.isEmpty(managementService.getAddress()));
+		assertEquals(
+				"management service address must equals hostname from discovery properties",
+				discoveryProperties.getHostname(), managementService.getAddress());
 	}
 
 	@Configuration
 	@EnableAutoConfiguration
-	@ImportAutoConfiguration({ AutoServiceRegistrationConfiguration.class, ConsulAutoConfiguration.class, ConsulAutoServiceRegistrationAutoConfiguration.class })
-	public static class TestConfig { }
+	@ImportAutoConfiguration({ AutoServiceRegistrationConfiguration.class,
+			ConsulAutoConfiguration.class,
+			ConsulAutoServiceRegistrationAutoConfiguration.class })
+	public static class TestConfig {
+	}
 }

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationManagementServiceTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationManagementServiceTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.consul.serviceregistry;
 
+import static org.junit.Assert.*;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
 import java.util.Map;
 
 import org.junit.Test;
@@ -35,21 +38,15 @@ import com.ecwid.consul.v1.ConsulClient;
 import com.ecwid.consul.v1.Response;
 import com.ecwid.consul.v1.agent.model.Service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-
 /**
  * @author Aleksandr Tarasov (aatarasov)
+ * @author Lomesh Patel (lomeshpatel)
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = ConsulAutoServiceRegistrationManagementServiceTests.TestConfig.class, properties =
-		{"spring.application.name=myTestService-EE",
-				"spring.cloud.consul.discovery.instanceId=myTestService1-EE",
-				"spring.cloud.consul.discovery.registerHealthCheck=false",
-				"management.server.port=0"},
-		webEnvironment = RANDOM_PORT)
+@SpringBootTest(classes = ConsulAutoServiceRegistrationManagementServiceTests.TestConfig.class, properties = {
+		"spring.application.name=myTestService-EE",
+		"spring.cloud.consul.discovery.registerHealthCheck=false",
+		"management.server.port=4452" }, webEnvironment = RANDOM_PORT)
 public class ConsulAutoServiceRegistrationManagementServiceTests {
 
 	@Autowired
@@ -60,19 +57,39 @@ public class ConsulAutoServiceRegistrationManagementServiceTests {
 
 	@Test
 	public void contextLoads() {
-		Response<Map<String, Service>> response = consul.getAgentServices();
-		Map<String, Service> services = response.getValue();
-		Service service = services.get("myTestService-EE-0-management");
+		final Response<Map<String, Service>> response = consul.getAgentServices();
+		final Map<String, Service> services = response.getValue();
+
+		final Service service = services.get("myTestService-EE-0");
 		assertNotNull("service was null", service);
-		assertEquals("service port is not 0", 0, service.getPort().intValue());
-		assertEquals("service id was wrong", "myTestService-EE-0-management", service.getId());
-		assertEquals("service name was wrong", "myTestService-EE-management", service.getService());
-		assertFalse("service address must not be empty", StringUtils.isEmpty(service.getAddress()));
-		assertEquals("service address must equals hostname from discovery properties", discoveryProperties.getHostname(), service.getAddress());
+		assertNotEquals("service port was 0", 0, service.getPort().intValue());
+		assertEquals("service id was wrong", "myTestService-EE-0", service.getId());
+		assertEquals("service name was wrong", "myTestService-EE", service.getService());
+		assertFalse("service address must not be empty",
+				StringUtils.isEmpty(service.getAddress()));
+		assertEquals("service address must equals hostname from discovery properties",
+				discoveryProperties.getHostname(), service.getAddress());
+
+		final Service managementService = services.get("myTestService-EE-0-management");
+		assertNotNull("management service was null", managementService);
+		assertEquals("management service port was wrong", 4452,
+				managementService.getPort().intValue());
+		assertEquals("management service id was wrong", "myTestService-EE-0-management",
+				managementService.getId());
+		assertEquals("management service name was wrong", "myTestService-EE-management",
+				managementService.getService());
+		assertFalse("management service address must not be empty",
+				StringUtils.isEmpty(managementService.getAddress()));
+		assertEquals(
+				"management service address must equals hostname from discovery properties",
+				discoveryProperties.getHostname(), managementService.getAddress());
 	}
 
 	@Configuration
 	@EnableAutoConfiguration
-	@ImportAutoConfiguration({ AutoServiceRegistrationConfiguration.class, ConsulAutoConfiguration.class, ConsulAutoServiceRegistrationAutoConfiguration.class })
-	public static class TestConfig { }
+	@ImportAutoConfiguration({ AutoServiceRegistrationConfiguration.class,
+			ConsulAutoConfiguration.class,
+			ConsulAutoServiceRegistrationAutoConfiguration.class })
+	public static class TestConfig {
+	}
 }

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationManagementServiceTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoServiceRegistrationManagementServiceTests.java
@@ -16,7 +16,10 @@
 
 package org.springframework.cloud.consul.serviceregistry;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 import java.util.Map;


### PR DESCRIPTION
- If instanceId and/or serviceName is customized, they're also applied
to the management service registration
- Updated documentation to provide information about management service

Fixes gh-443