### PR TITLE
Modify the getServices() method so that it filters on default-query-tag

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClient.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClient.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.consul.discovery;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.ecwid.consul.v1.ConsulClient;
 import com.ecwid.consul.v1.QueryParams;
@@ -119,12 +120,24 @@ public class ConsulDiscoveryClient implements DiscoveryClient {
 	public List<String> getServices() {
 		String aclToken = properties.getAclToken();
 
+		Map<String, List<String>> services;
 		if (StringUtils.hasText(aclToken)) {
-			return new ArrayList<>(client.getCatalogServices(QueryParams.DEFAULT, aclToken).getValue()
-					.keySet());
+			services = client.getCatalogServices(QueryParams.DEFAULT, aclToken).getValue();
 		} else {
-			return new ArrayList<>(client.getCatalogServices(QueryParams.DEFAULT).getValue()
-					.keySet());
+			services = client.getCatalogServices(QueryParams.DEFAULT).getValue();
+		}
+
+		return services.entrySet().stream()
+				.filter(e -> defaultQueryTagFilter(e.getValue()))
+				.map(Map.Entry::getKey)
+				.collect(Collectors.toList());
+	}
+
+	private boolean defaultQueryTagFilter(List<String> tags) {
+		if (StringUtils.isEmpty(properties.getDefaultQueryTag())) {
+			return true;
+		} else {
+			return tags.contains(properties.getDefaultQueryTag());
 		}
 	}
 

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClientDefaultQueryTagTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClientDefaultQueryTagTests.java
@@ -84,6 +84,18 @@ public class ConsulDiscoveryClientDefaultQueryTagTests {
 		assertThat("instance is not intg", instances.get(0).getMetadata(), hasEntry("intg", "intg"));
 	}
 
+	@Test
+	public void shouldReturnOnlyIntgService() {
+		List<String> services = discoveryClient.getServices();
+		assertThat("instances was wrong size", services, hasSize(1));
+		assertThat("instance is not intg", services.get(0).equals(NAME));
+	}
+
+	@Test
+	public void returnAllServicesIfTagNotSet() {
+
+	}
+
 	private NewService serviceForEnvironment(String env, int port) {
 		NewService service = new NewService();
 		service.setAddress("localhost");

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClientTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClientTests.java
@@ -78,6 +78,13 @@ public class ConsulDiscoveryClientTests {
 		assertIpAddress(instance);
 	}
 
+	@Test
+	public void getServicesWorks() {
+		List<String> services = discoveryClient.getServices();
+		assertNotNull("services was null", services);
+		assertFalse("services was empty", services.isEmpty());
+	}
+
 	private void assertIpAddress(ServiceInstance instance) {
 		assertTrue("host isn't an ip address",
 				Character.isDigit(instance.getHost().charAt(0)));


### PR DESCRIPTION
This PR modifies `ConsulDiscoveryClient` so that its `getServices()` method takes into account the value of `default-query-tag` if it is set.

Further details are available in issue #452.