### PR TITLE
Add @ConditionalOnMissingBean

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClientConfiguration.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClientConfiguration.java
@@ -59,12 +59,14 @@ public class ConsulDiscoveryClientConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean
 	//TODO: move to service-registry for Edgware
 	public HeartbeatProperties heartbeatProperties() {
 		return new HeartbeatProperties();
 	}
 
 	@Bean
+	@ConditionalOnMissingBean
 	//TODO: Split appropriate values to service-registry for Edgware
 	public ConsulDiscoveryProperties consulDiscoveryProperties(InetUtils inetUtils) {
 		return new ConsulDiscoveryProperties(inetUtils);


### PR DESCRIPTION
In Apache Camel we had some tests fail when upgrading to Spring Boot 2.1
we narrowed it down to missing `@ConditionalOnMissingBean`. I guess the
processing order for auto-configurations changed between Spring Boot 2.0
and 2.1 and this issue surfaced.

The tests that failed are here:

https://github.com/apache/camel/tree/master/components/camel-spring-cloud-consul/src/test/java/org/apache/camel/spring/cloud/consul