### PR TITLE
fix #471 again-Service check TTL

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoRegistration.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoRegistration.java
@@ -127,6 +127,8 @@ public class ConsulAutoRegistration extends ConsulRegistration {
 			}
 			Assert.notNull(checkPort, "checkPort may not be null");
 			service.setCheck(createCheck(checkPort, heartbeatProperties, properties));
+		}else if (heartbeatProperties.isEnabled() && service.getCheck() == null)) {
+			service.setCheck(createCheck(0, heartbeatProperties, properties));
 		}
 	}
 
@@ -145,6 +147,8 @@ public class ConsulAutoRegistration extends ConsulRegistration {
 		if (properties.isRegisterHealthCheck()) {
 			management.setCheck(createCheck(getManagementPort(properties, context),
 					heartbeatProperties, properties));
+		}else if (heartbeatProperties.isEnabled() && service.getCheck() == null)) {
+			management.setCheck(createCheck(0, heartbeatProperties, properties));
 		}
 		ConsulAutoRegistration registration = new ConsulAutoRegistration(management,
 				autoServiceRegistrationProperties, properties, context,


### PR DESCRIPTION
Though #471 had been closed, I think that the fix was not enough.
The true reason is, when the service was registered, the TTL was not set.
So we need to set TTL when RegisterHealthCheck() is false and heartbeatProperties.isEnabled() is true.
 The settings are:
spring.cloud.consul.discovery.register-health-check=false
spring.cloud.consul.discovery.heartbeat.enabled=true

I had fixed it with my SpringCloud Finchley, and copied the changes to master branch.
And I find that function createCheck() had been fixed with moving HealthCheckCriticalTimeout to the top of this function.

So there are two places need to be fixed!