### PR TITLE
refix #471 for service-ttl error

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoRegistration.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoRegistration.java
@@ -128,6 +128,9 @@ public class ConsulAutoRegistration extends ConsulRegistration {
 			Assert.notNull(checkPort, "checkPort may not be null");
 			service.setCheck(createCheck(checkPort, heartbeatProperties, properties));
 		}
+		else if (heartbeatProperties.isEnabled() && service.getCheck() == null) {
+			service.setCheck(createCheck(0, heartbeatProperties, properties));
+		}
 	}
 
 	public static ConsulAutoRegistration managementRegistration(
@@ -145,6 +148,9 @@ public class ConsulAutoRegistration extends ConsulRegistration {
 		if (properties.isRegisterHealthCheck()) {
 			management.setCheck(createCheck(getManagementPort(properties, context),
 					heartbeatProperties, properties));
+		}
+		else if (heartbeatProperties.isEnabled() && management.getCheck() == null) {
+			management.setCheck(createCheck(0, heartbeatProperties, properties));
 		}
 		ConsulAutoRegistration registration = new ConsulAutoRegistration(management,
 				autoServiceRegistrationProperties, properties, context,

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoRegistrationHealthCheckHttpTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoRegistrationHealthCheckHttpTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.serviceregistry;
+
+import com.ecwid.consul.v1.agent.model.NewService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
+import org.springframework.cloud.consul.ConsulAutoConfiguration;
+import org.springframework.cloud.consul.discovery.ConsulDiscoveryProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * @author Patrick Hi
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = ConsulAutoRegistrationHealthCheckHttpTests.TestConfig.class,
+		properties = { "spring.application.name=myTestService-DiscoveryHealthCheckHttp",
+				"spring.cloud.consul.discovery.register-health-check=true",
+				"spring.cloud.consul.discovery.heartbeat.enabled=false" },
+		webEnvironment = RANDOM_PORT)
+public class ConsulAutoRegistrationHealthCheckHttpTests {
+
+	@Autowired
+	private ConsulAutoRegistration registration;
+
+	@Autowired
+	private ConsulDiscoveryProperties properties;
+
+	@Test
+	public void contextLoads() {
+		NewService service = this.registration.getService();
+		assertThat(service).as("service was null").isNotNull();
+
+		NewService.Check check = service.getCheck();
+		assertThat(check).as("check was null").isNotNull();
+		assertThat(check.getHttp()).as("http was null").isNotNull();
+		assertThat(check.getTtl()).as("ttl was not null").isNull();
+		// unable to call consul api to get health check details
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	@ImportAutoConfiguration({ AutoServiceRegistrationConfiguration.class,
+			ConsulAutoConfiguration.class,
+			ConsulAutoServiceRegistrationAutoConfiguration.class })
+	public static class TestConfig {
+
+	}
+
+}

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoRegistrationHeartBeatTtlTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/serviceregistry/ConsulAutoRegistrationHeartBeatTtlTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.serviceregistry;
+
+import com.ecwid.consul.v1.agent.model.NewService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationConfiguration;
+import org.springframework.cloud.consul.ConsulAutoConfiguration;
+import org.springframework.cloud.consul.discovery.ConsulDiscoveryProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * @author Patrick Hi
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = ConsulAutoRegistrationHeartBeatTtlTests.TestConfig.class,
+		properties = { "spring.application.name=myTestService-DiscoveryHeartBeatTtl",
+				"spring.cloud.consul.discovery.register-health-check=false",
+				"spring.cloud.consul.discovery.heartbeat.enabled=true" },
+		webEnvironment = RANDOM_PORT)
+public class ConsulAutoRegistrationHeartBeatTtlTests {
+
+	@Autowired
+	private ConsulAutoRegistration registration;
+
+	@Autowired
+	private ConsulDiscoveryProperties properties;
+
+	@Test
+	public void contextLoads() {
+		NewService service = this.registration.getService();
+		assertThat(service).as("service was null").isNotNull();
+
+		NewService.Check check = service.getCheck();
+		assertThat(check).as("check was null").isNotNull();
+		assertThat(check.getHttp()).as("http was not null").isNull();
+		assertThat(check.getTtl()).as("ttl was null").isNotNull();
+		// unable to call consul api to get health check details
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	@ImportAutoConfiguration({ AutoServiceRegistrationConfiguration.class,
+			ConsulAutoConfiguration.class,
+			ConsulAutoServiceRegistrationAutoConfiguration.class })
+	public static class TestConfig {
+
+	}
+
+}


### PR DESCRIPTION
Though #471 had been closed, I think the fix was not enough.
The real reason is, when the service was registered, the TTL was not set.
So we need to set TTL when RegisterHealthCheck() is false and heartbeatProperties.isEnabled() is true.
The settings are:
spring.cloud.consul.discovery.register-health-check=false
spring.cloud.consul.discovery.heartbeat.enabled=true

I had fixed it with my SpringCloud Finchley, and copied the changes to master branch.
And I find that function createCheck() had been fixed with moving HealthCheckCriticalTimeout to the top of this function.

There are still two places need to be fixed!