### PR TITLE
Add consistency mode setting

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClient.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClient.java
@@ -61,7 +61,7 @@ public class ConsulDiscoveryClient implements DiscoveryClient {
 
 	@Override
 	public List<ServiceInstance> getInstances(final String serviceId) {
-		return getInstances(serviceId, QueryParams.DEFAULT);
+		return getInstances(serviceId, new QueryParams(this.properties.getConsistencyMode()));
 	}
 
 	public List<ServiceInstance> getInstances(final String serviceId,

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.ecwid.consul.v1.ConsistencyMode;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.commons.util.InetUtils;
@@ -119,6 +121,11 @@ public class ConsulDiscoveryProperties {
 	 * Whether hostname is included into the default instance id when registering service.
 	 */
 	private boolean includeHostnameInInstanceId = false;
+
+	/**
+	 * Consistency mode for health service request.
+	 */
+	private ConsistencyMode consistencyMode = ConsistencyMode.DEFAULT;
 
 	/**
 	 * Service instance zone comes from metadata. This allows changing the metadata tag
@@ -403,6 +410,14 @@ public class ConsulDiscoveryProperties {
 		this.includeHostnameInInstanceId = includeHostnameInInstanceId;
 	}
 
+	public ConsistencyMode getConsistencyMode() {
+		return consistencyMode;
+	}
+
+	public void setConsistencyMode(ConsistencyMode consistencyMode) {
+		this.consistencyMode = consistencyMode;
+	}
+
 	public String getDefaultZoneMetadataName() {
 		return this.defaultZoneMetadataName;
 	}
@@ -526,6 +541,8 @@ public class ConsulDiscoveryProperties {
 				.append("preferAgentAddress", this.preferAgentAddress)
 				.append("catalogServicesWatchDelay", this.catalogServicesWatchDelay)
 				.append("catalogServicesWatchTimeout", this.catalogServicesWatchTimeout)
+				.append("includeHostnameInInstanceId", this.includeHostnameInInstanceId)
+				.append("consistencyMode", this.consistencyMode)
 				.append("serviceName", this.serviceName)
 				.append("instanceId", this.instanceId)
 				.append("instanceZone", this.instanceZone)

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServerList.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServerList.java
@@ -30,6 +30,7 @@ import com.netflix.loadbalancer.AbstractServerList;
 /**
  * @author Spencer Gibb
  * @author Richard Kettelerij
+ * @author Varnson Fan
  */
 public class ConsulServerList extends AbstractServerList<ConsulServer> {
 
@@ -115,9 +116,9 @@ public class ConsulServerList extends AbstractServerList<ConsulServer> {
 	protected QueryParams createQueryParamsForClientRequest() {
 		String datacenter = getDatacenter();
 		if (datacenter != null) {
-			return new QueryParams(datacenter);
+			return new QueryParams(datacenter, this.properties.getConsistencyMode());
 		}
-		return QueryParams.DEFAULT;
+		return new QueryParams(this.properties.getConsistencyMode());
 	}
 
 	protected String getTag() {

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulServerListConsistencyModeDefaultTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulServerListConsistencyModeDefaultTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.discovery;
+
+import com.ecwid.consul.v1.ConsistencyMode;
+import com.ecwid.consul.v1.ConsulClient;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * @author Varnson Fan
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = ConsulServerListConsistencyModeDefaultTests.TestConfig.class,
+		properties = { "spring.application.name=testConsulServerListConsistencyMode",
+				"spring.cloud.consul.discovery.preferIpAddress=true" },
+		webEnvironment = RANDOM_PORT)
+public class ConsulServerListConsistencyModeDefaultTests {
+
+	@Autowired
+	private ConsulClient consulClient;
+
+	@Autowired
+	private ConsulDiscoveryProperties properties;
+
+	@Test
+	public void serverListWorksWithConsistencyMode() {
+		ConsulServerList consulServerList = new ConsulServerList(this.consulClient,
+				this.properties);
+
+		assertThat(consulServerList.getProperties().getConsistencyMode()
+				.equals(ConsistencyMode.DEFAULT)).as("ConsistencyMode is default")
+						.isTrue();
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	@EnableDiscoveryClient
+	public static class TestConfig {
+
+	}
+
+}

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulServerListConsistencyModeStaleTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulServerListConsistencyModeStaleTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.discovery;
+
+import com.ecwid.consul.v1.ConsistencyMode;
+import com.ecwid.consul.v1.ConsulClient;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * @author Varnson Fan
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = ConsulServerListConsistencyModeStaleTests.TestConfig.class,
+		properties = { "spring.application.name=testConsulServerListConsistencyMode",
+				"spring.cloud.consul.discovery.preferIpAddress=true",
+				"spring.cloud.consul.discovery.consistencyMode=STALE" },
+		webEnvironment = RANDOM_PORT)
+public class ConsulServerListConsistencyModeStaleTests {
+
+	@Autowired
+	private ConsulClient consulClient;
+
+	@Autowired
+	private ConsulDiscoveryProperties properties;
+
+	@Test
+	public void serverListWorksWithConsistencyMode() {
+		ConsulServerList consulServerList = new ConsulServerList(this.consulClient,
+				this.properties);
+
+		assertThat(consulServerList.getProperties().getConsistencyMode()
+				.equals(ConsistencyMode.STALE)).as("ConsistencyMode is stale").isTrue();
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	@EnableDiscoveryClient
+	public static class TestConfig {
+
+	}
+
+}


### PR DESCRIPTION
fix #556:
add  consistency mode  in ConsulDiscoveryProperties, modify ConsulDiscoveryClient.java  and ConsulServerList.java to use the consistency mode from ConsulDiscoveryProperties.