### PR TITLE
add option to configure Consul check status considered as healthy

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
@@ -17,11 +17,15 @@
 package org.springframework.cloud.consul.discovery;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.ecwid.consul.v1.ConsistencyMode;
+import com.ecwid.consul.v1.health.model.Check;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -159,6 +163,12 @@ public class ConsulDiscoveryProperties {
 	 * check passing to the server.
 	 */
 	private boolean queryPassing = false;
+
+	/**
+	 * List of status considered as healthy. Contains "passing" by default.
+	 */
+	private Set<Check.CheckStatus> statusConsideredAsHealthy = new HashSet(
+			Collections.singleton(Check.CheckStatus.PASSING));
 
 	/** Register as a service in consul. */
 	private boolean register = true;
@@ -470,8 +480,17 @@ public class ConsulDiscoveryProperties {
 		return this.queryPassing;
 	}
 
+	public Set<Check.CheckStatus> getStatusConsideredAsHealthy() {
+		return statusConsideredAsHealthy;
+	}
+
 	public void setQueryPassing(boolean queryPassing) {
 		this.queryPassing = queryPassing;
+	}
+
+	public void setStatusConsideredAsHealthy(
+			Set<Check.CheckStatus> statusConsideredAsHealthy) {
+		this.statusConsideredAsHealthy = statusConsideredAsHealthy;
 	}
 
 	public boolean isRegister() {

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServer.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServer.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.consul.discovery;
 
 import java.util.Map;
+import java.util.Set;
 
 import com.ecwid.consul.v1.health.model.Check;
 import com.ecwid.consul.v1.health.model.HealthService;
@@ -33,11 +34,15 @@ public class ConsulServer extends Server {
 
 	private final HealthService service;
 
+	private final Set<Check.CheckStatus> statusConsideredAsHealthy;
+
 	private final Map<String, String> metadata;
 
-	public ConsulServer(final HealthService healthService) {
+	public ConsulServer(final HealthService healthService,
+			Set<Check.CheckStatus> statusConsideredAsHealthy) {
 		super(findHost(healthService), healthService.getService().getPort());
 		this.service = healthService;
+		this.statusConsideredAsHealthy = statusConsideredAsHealthy;
 		this.metadata = ConsulServerUtils.getMetadata(this.service);
 		this.metaInfo = new MetaInfo() {
 			@Override
@@ -79,7 +84,7 @@ public class ConsulServer extends Server {
 
 	public boolean isPassingChecks() {
 		for (Check check : this.service.getChecks()) {
-			if (check.getStatus() != Check.CheckStatus.PASSING) {
+			if (!statusConsideredAsHealthy.contains(check.getStatus())) {
 				return false;
 			}
 		}

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryPropertiesTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryPropertiesTests.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.consul.discovery;
 import java.util.Collections;
 import java.util.Map;
 
+import com.ecwid.consul.v1.health.model.Check;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -93,6 +94,19 @@ public class ConsulDiscoveryPropertiesTests {
 		this.properties.getManagementTags().add("newTag");
 		assertThat(this.properties.getManagementTags())
 				.containsOnly(ConsulDiscoveryProperties.MANAGEMENT, "newTag");
+	}
+
+	@Test
+	public void testConsiderStatusAsHealthyContainsPassingByDefault() {
+		assertThat(this.properties.getStatusConsideredAsHealthy())
+				.containsExactly(Check.CheckStatus.PASSING);
+	}
+
+	@Test
+	public void testConsiderWarningStatusAsHealthy() {
+		this.properties.getStatusConsideredAsHealthy().add(Check.CheckStatus.WARNING);
+		assertThat(this.properties.getStatusConsideredAsHealthy())
+				.containsExactly(Check.CheckStatus.WARNING, Check.CheckStatus.PASSING);
 	}
 
 }

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulServerTest.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulServerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.discovery;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.ecwid.consul.v1.health.model.Check;
+import com.ecwid.consul.v1.health.model.HealthService;
+import org.junit.Test;
+
+import static com.ecwid.consul.v1.health.model.Check.CheckStatus.CRITICAL;
+import static com.ecwid.consul.v1.health.model.Check.CheckStatus.PASSING;
+import static com.ecwid.consul.v1.health.model.Check.CheckStatus.WARNING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Christian Lorenz
+ */
+public class ConsulServerTest {
+
+	@Test
+	public void testIsPassingChecks() {
+		Set<Check.CheckStatus> acceptedStatus = new HashSet<>(
+				Arrays.asList(PASSING, WARNING));
+		assertThat(newServer(PASSING, acceptedStatus).isPassingChecks()).isTrue();
+		assertThat(newServer(WARNING, acceptedStatus).isPassingChecks()).isTrue();
+		assertThat(newServer(CRITICAL, acceptedStatus).isPassingChecks()).isFalse();
+	}
+
+	static ConsulServer newServer(Check.CheckStatus checkStatus,
+			Set<Check.CheckStatus> acceptedStatus) {
+		HealthService healthService = new HealthService();
+		HealthService.Node node = new HealthService.Node();
+		node.setAddress("nodeaddr" + checkStatus.name());
+		node.setNode("nodenode" + checkStatus.name());
+		healthService.setNode(node);
+		HealthService.Service service = new HealthService.Service();
+		service.setAddress("serviceaddr" + checkStatus.name());
+		service.setId("serviceid" + checkStatus.name());
+		service.setPort(8080);
+		service.setService("serviceservice" + checkStatus.name());
+		healthService.setService(service);
+		ArrayList<Check> checks = new ArrayList<>();
+		Check check = new Check();
+		check.setStatus(checkStatus);
+		checks.add(check);
+		healthService.setChecks(checks);
+		return new ConsulServer(healthService, acceptedStatus);
+	}
+
+}

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/HealthServiceServerListFilterTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/HealthServiceServerListFilterTests.java
@@ -17,10 +17,9 @@
 package org.springframework.cloud.consul.discovery;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-import com.ecwid.consul.v1.health.model.Check;
-import com.ecwid.consul.v1.health.model.HealthService;
 import com.netflix.loadbalancer.Server;
 import org.junit.Test;
 
@@ -28,6 +27,7 @@ import static com.ecwid.consul.v1.health.model.Check.CheckStatus.CRITICAL;
 import static com.ecwid.consul.v1.health.model.Check.CheckStatus.PASSING;
 import static com.ecwid.consul.v1.health.model.Check.CheckStatus.WARNING;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.consul.discovery.ConsulServerTest.newServer;
 
 /**
  * @author Spencer Gibb
@@ -39,33 +39,13 @@ public class HealthServiceServerListFilterTests {
 		HealthServiceServerListFilter filter = new HealthServiceServerListFilter();
 
 		ArrayList<Server> servers = new ArrayList<>();
-		servers.add(newServer(PASSING));
-		servers.add(newServer(PASSING));
-		servers.add(newServer(CRITICAL));
-		servers.add(newServer(WARNING));
+		servers.add(newServer(PASSING, Collections.singleton(PASSING)));
+		servers.add(newServer(PASSING, Collections.singleton(PASSING)));
+		servers.add(newServer(CRITICAL, Collections.singleton(PASSING)));
+		servers.add(newServer(WARNING, Collections.singleton(PASSING)));
 
 		List<Server> filtered = filter.getFilteredListOfServers(servers);
 		assertThat(filtered).as("wrong # of filtered servers").hasSize(2);
-	}
-
-	private ConsulServer newServer(Check.CheckStatus checkStatus) {
-		HealthService healthService = new HealthService();
-		HealthService.Node node = new HealthService.Node();
-		node.setAddress("nodeaddr" + checkStatus.name());
-		node.setNode("nodenode" + checkStatus.name());
-		healthService.setNode(node);
-		HealthService.Service service = new HealthService.Service();
-		service.setAddress("serviceaddr" + checkStatus.name());
-		service.setId("serviceid" + checkStatus.name());
-		service.setPort(8080);
-		service.setService("serviceservice" + checkStatus.name());
-		healthService.setService(service);
-		ArrayList<Check> checks = new ArrayList<>();
-		Check check = new Check();
-		check.setStatus(checkStatus);
-		checks.add(check);
-		healthService.setChecks(checks);
-		return new ConsulServer(healthService);
 	}
 
 }


### PR DESCRIPTION
Instead of just considering check status "passing" as healthy we make the status configurable. That allows us to also consider e.g. "warning" as healthy.

Default is the current behavior that only allows "passing".