### PR TITLE
Add support for multiple configuration path prefixes.

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-consul.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-consul.adoc
@@ -293,7 +293,7 @@ The watch uses a Spring `TaskScheduler` to schedule the call to consul. By defau
 [[spring-cloud-consul-config]]
 == Distributed Configuration with Consul
 
-Consul provides a https://consul.io/docs/agent/http/kv.html[Key/Value Store] for storing configuration and other metadata.  Spring Cloud Consul Config is an alternative to the https://github.com/spring-cloud/spring-cloud-config[Config Server and Client].  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the `/config` folder by default.  Multiple `PropertySource` instances are created based on the application's name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:
+Consul provides a https://consul.io/docs/agent/http/kv.html[Key/Value Store] for storing configuration and other metadata.  Spring Cloud Consul Config is an alternative to the https://github.com/spring-cloud/spring-cloud-config[Config Server and Client].  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the `/config` folder by default.  Multiple `PropertySource` instances are created based on the application's name and the active profiles that mimics the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:
 
 ----
 config/testApp,dev/

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.consul.config;
 
+import java.util.Collections;
+import java.util.List;
+
 import javax.annotation.PostConstruct;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -34,7 +37,7 @@ public class ConsulConfigProperties {
 
 	private boolean enabled = true;
 
-	private String prefix = "config";
+	private List<String> prefixes = Collections.singletonList("config");
 
 	@NotEmpty
 	private String defaultContext = "application";
@@ -85,12 +88,17 @@ public class ConsulConfigProperties {
 		this.enabled = enabled;
 	}
 
-	public String getPrefix() {
-		return this.prefix;
+	public List<String> getPrefixes() {
+		return this.prefixes;
 	}
 
+	public void setPrefixes(List<String> prefixes) {
+		this.prefixes = prefixes;
+	}
+
+	@Deprecated
 	public void setPrefix(String prefix) {
-		this.prefix = prefix;
+		this.prefixes = Collections.singletonList(prefix);
 	}
 
 	public @NotEmpty String getDefaultContext() {
@@ -160,7 +168,7 @@ public class ConsulConfigProperties {
 	@Override
 	public String toString() {
 		return new ToStringCreator(this).append("enabled", this.enabled)
-				.append("prefix", this.prefix)
+				.append("prefixes", this.prefixes)
 				.append("defaultContext", this.defaultContext)
 				.append("profileSeparator", this.profileSeparator)
 				.append("format", this.format).append("dataKey", this.dataKey)

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocator.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocator.java
@@ -86,35 +86,36 @@ public class ConsulPropertySourceLocator implements PropertySourceLocator {
 
 			List<String> profiles = Arrays.asList(env.getActiveProfiles());
 
-			String prefix = this.properties.getPrefix();
+			for (String prefix : this.properties.getPrefixes()) {
 
-			List<String> suffixes = new ArrayList<>();
-			if (this.properties.getFormat() != FILES) {
-				suffixes.add("/");
-			}
-			else {
-				suffixes.add(".yml");
-				suffixes.add(".yaml");
-				suffixes.add(".properties");
-			}
+				List<String> suffixes = new ArrayList<>();
+				if (this.properties.getFormat() != FILES) {
+					suffixes.add("/");
+				}
+				else {
+					suffixes.add(".yml");
+					suffixes.add(".yaml");
+					suffixes.add(".properties");
+				}
 
-			String defaultContext = getContext(prefix,
-					this.properties.getDefaultContext());
+				String defaultContext = getContext(prefix,
+						this.properties.getDefaultContext());
 
-			for (String suffix : suffixes) {
-				this.contexts.add(defaultContext + suffix);
-			}
-			for (String suffix : suffixes) {
-				addProfiles(this.contexts, defaultContext, profiles, suffix);
-			}
+				for (String suffix : suffixes) {
+					this.contexts.add(defaultContext + suffix);
+				}
+				for (String suffix : suffixes) {
+					addProfiles(this.contexts, defaultContext, profiles, suffix);
+				}
 
-			String baseContext = getContext(prefix, appName);
+				String baseContext = getContext(prefix, appName);
 
-			for (String suffix : suffixes) {
-				this.contexts.add(baseContext + suffix);
-			}
-			for (String suffix : suffixes) {
-				addProfiles(this.contexts, baseContext, profiles, suffix);
+				for (String suffix : suffixes) {
+					this.contexts.add(baseContext + suffix);
+				}
+				for (String suffix : suffixes) {
+					addProfiles(this.contexts, baseContext, profiles, suffix);
+				}
 			}
 
 			Collections.reverse(this.contexts);

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigBootstrapConfigurationTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigBootstrapConfigurationTests.java
@@ -40,7 +40,7 @@ public class ConsulConfigBootstrapConfigurationTests {
 				.run(context -> {
 					ConsulConfigProperties config = context
 							.getBean(ConsulConfigProperties.class);
-					assertThat(config.getPrefix()).as("Prefix did not match")
+					assertThat(config.getPrefixes().get(0)).as("Prefix did not match")
 							.isEqualTo("platform-config");
 					assertThat(config.getDefaultContext())
 							.as("Default context did not match").isEqualTo("defaults");
@@ -57,7 +57,7 @@ public class ConsulConfigBootstrapConfigurationTests {
 				.run(context -> {
 					ConsulConfigProperties config = context
 							.getBean(ConsulConfigProperties.class);
-					assertThat(config.getPrefix()).as("Prefix did not match")
+					assertThat(config.getPrefixes().get(0)).as("Prefix did not match")
 							.isEqualTo("config");
 					assertThat(config.getDefaultContext())
 							.as("Default context did not match").isEqualTo("application");


### PR DESCRIPTION
This is the most basic implementation to achieve the functionality. A bit more work would need to be done if a different property source order was desired.

Fixes gh-450