### PR TITLE
fix(shellScript): download correct consul zip for arm64 processor

### DIFF
--- a/src/main/bash/ci_install_consul.sh
+++ b/src/main/bash/ci_install_consul.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 CONSUL_VER="1.7.2"
-CONSUL_ZIP="consul_${CONSUL_VER}_linux_amd64.zip"
+PLATFORM="amd64"
+if [ "$(uname -m)" == aarch64 ]; then
+  PLATFORM="arm64"
+fi
+CONSUL_ZIP="consul_${CONSUL_VER}_linux_${PLATFORM}.zip"
 IGNORE_CERTS="${IGNORE_CERTS:-no}"
 
 # cleanup


### PR DESCRIPTION
ci_install_consul.sh just downloads the consul for amd64, which cannot be executed on arm64 architecture processors.
Add achitecture checking in this script to support downloading correct binary file.

Signed-off-by: maaaace <fuheming@huawei.com>