### PR TITLE
Fixes #416 The problem of multiple keys in ConfigWatch

### DIFF
--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConfigWatch.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConfigWatch.java
@@ -130,6 +130,7 @@ public class ConfigWatch implements ApplicationEventPublisherAware, SmartLifecyc
 		if (!this.running.get()) {
 			return;
 		}
+		int waitTime = this.properties.getWatch().getWaitTime();
 		for (String context : this.consulIndexes.keySet()) {
 
 			// turn the context into a Consul folder path (unless our config format
@@ -155,7 +156,8 @@ public class ConfigWatch implements ApplicationEventPublisherAware, SmartLifecyc
 				}
 
 				Response<List<GetValue>> response = this.consul.getKVValues(context, aclToken,
-						new QueryParams(this.properties.getWatch().getWaitTime(), currentIndex));
+						new QueryParams(waitTime, currentIndex));
+				waitTime = 1;
 
 				// if response.value == null, response was a 404, otherwise it was a
 				// 200, reducing churn if there wasn't anything


### PR DESCRIPTION
for multiple configurations, generally the first one is the main configuration.
so only the first configuration needs to be watch, the other will wait 1 second.
(if waitTime=0, will wait 5 minutes)