### PR TITLE
Use abstract config data post processor

### DIFF
--- a/spring-cloud-consul-config/pom.xml
+++ b/spring-cloud-consul-config/pom.xml
@@ -20,7 +20,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-commons</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-consul-config/pom.xml
+++ b/spring-cloud-consul-config/pom.xml
@@ -18,6 +18,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-commons</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigDataMissingEnvironmentPostProcessor.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigDataMissingEnvironmentPostProcessor.java
@@ -16,21 +16,18 @@
 
 package org.springframework.cloud.consul.config;
 
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.context.config.ConfigDataEnvironmentPostProcessor;
 import org.springframework.boot.diagnostics.AbstractFailureAnalyzer;
 import org.springframework.boot.diagnostics.FailureAnalysis;
-import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.cloud.commons.ConfigDataMissingEnvironmentPostProcessor;
 import org.springframework.cloud.consul.ConsulProperties;
-import org.springframework.core.Ordered;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.util.StringUtils;
+import org.springframework.core.env.Environment;
 
 import static org.springframework.cloud.consul.config.ConsulConfigDataLocationResolver.PREFIX;
 import static org.springframework.cloud.util.PropertyUtils.bootstrapEnabled;
 import static org.springframework.cloud.util.PropertyUtils.useLegacyProcessing;
 
-public class ConsulConfigDataMissingEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
+public class ConsulConfigDataMissingEnvironmentPostProcessor extends ConfigDataMissingEnvironmentPostProcessor {
 
 	/**
 	 * Order of post processor, set to run after
@@ -44,37 +41,25 @@ public class ConsulConfigDataMissingEnvironmentPostProcessor implements Environm
 	}
 
 	@Override
-	public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+	protected boolean shouldProcessEnvironment(Environment environment) {
 		// don't run if using bootstrap or legacy processing
 		if (bootstrapEnabled(environment) || useLegacyProcessing(environment)) {
-			return;
+			return false;
 		}
 		boolean coreEnabled = environment.getProperty(ConsulProperties.PREFIX + ".enabled", Boolean.class, true);
 		boolean configEnabled = environment.getProperty(ConsulConfigProperties.PREFIX + ".enabled", Boolean.class,
-				true);
+			true);
 		boolean importCheckEnabled = environment.getProperty(ConsulConfigProperties.PREFIX + ".import-check.enabled",
-				Boolean.class, true);
+			Boolean.class, true);
 		if (!coreEnabled || !configEnabled || !importCheckEnabled) {
-			return;
+			return false;
 		}
-		String property = environment.getProperty("spring.config.import");
-		if (!StringUtils.hasText(property)) {
-			throw new ImportException("No spring.config.import set", false);
-		}
-		if (!property.contains(PREFIX)) {
-			throw new ImportException("spring.config.import missing " + PREFIX, true);
-		}
+		return true;
 	}
 
-	static class ImportException extends RuntimeException {
-
-		final boolean missingPrefix;
-
-		ImportException(String message, boolean missingPrefix) {
-			super(message);
-			this.missingPrefix = missingPrefix;
-		}
-
+	@Override
+	protected String getPrefix() {
+		return PREFIX;
 	}
 
 	static class ImportExceptionFailureAnalyzer extends AbstractFailureAnalyzer<ImportException> {

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigDataMissingEnvironmentPostProcessor.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigDataMissingEnvironmentPostProcessor.java
@@ -48,9 +48,9 @@ public class ConsulConfigDataMissingEnvironmentPostProcessor extends ConfigDataM
 		}
 		boolean coreEnabled = environment.getProperty(ConsulProperties.PREFIX + ".enabled", Boolean.class, true);
 		boolean configEnabled = environment.getProperty(ConsulConfigProperties.PREFIX + ".enabled", Boolean.class,
-			true);
+				true);
 		boolean importCheckEnabled = environment.getProperty(ConsulConfigProperties.PREFIX + ".import-check.enabled",
-			Boolean.class, true);
+				Boolean.class, true);
 		if (!coreEnabled || !configEnabled || !importCheckEnabled) {
 			return false;
 		}

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigDataMissingEnvironmentPostProcessorTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigDataMissingEnvironmentPostProcessorTests.java
@@ -36,7 +36,7 @@ class ConsulConfigDataMissingEnvironmentPostProcessorTests {
 		SpringApplication app = mock(SpringApplication.class);
 		ConsulConfigDataMissingEnvironmentPostProcessor processor = new ConsulConfigDataMissingEnvironmentPostProcessor();
 		assertThatThrownBy(() -> processor.postProcessEnvironment(environment, app))
-			.isInstanceOf(ConsulConfigDataMissingEnvironmentPostProcessor.ImportException.class);
+				.isInstanceOf(ConsulConfigDataMissingEnvironmentPostProcessor.ImportException.class);
 	}
 
 	@Test

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigDataMissingEnvironmentPostProcessorTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigDataMissingEnvironmentPostProcessorTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.config;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Ryan Baxter
+ */
+class ConsulConfigDataMissingEnvironmentPostProcessorTests {
+
+	@Test
+	void noSpringConfigImport() {
+		MockEnvironment environment = new MockEnvironment();
+		SpringApplication app = mock(SpringApplication.class);
+		ConsulConfigDataMissingEnvironmentPostProcessor processor = new ConsulConfigDataMissingEnvironmentPostProcessor();
+		assertThatThrownBy(() -> processor.postProcessEnvironment(environment, app))
+			.isInstanceOf(ConsulConfigDataMissingEnvironmentPostProcessor.ImportException.class);
+	}
+
+	@Test
+	void boostrap() {
+		MockEnvironment environment = new MockEnvironment();
+		environment.setProperty("spring.cloud.bootstrap.enabled", "true");
+		SpringApplication app = mock(SpringApplication.class);
+		ConsulConfigDataMissingEnvironmentPostProcessor processor = new ConsulConfigDataMissingEnvironmentPostProcessor();
+		assertThatCode(() -> processor.postProcessEnvironment(environment, app)).doesNotThrowAnyException();
+	}
+
+	@Test
+	void legacy() {
+		MockEnvironment environment = new MockEnvironment();
+		environment.setProperty("spring.config.use-legacy-processing", "true");
+		SpringApplication app = mock(SpringApplication.class);
+		ConsulConfigDataMissingEnvironmentPostProcessor processor = new ConsulConfigDataMissingEnvironmentPostProcessor();
+		assertThatCode(() -> processor.postProcessEnvironment(environment, app)).doesNotThrowAnyException();
+	}
+
+	@Test
+	void configNotEnabled() {
+		MockEnvironment environment = new MockEnvironment();
+		environment.setProperty("spring.cloud.consul.enabled", "false");
+		SpringApplication app = mock(SpringApplication.class);
+		ConsulConfigDataMissingEnvironmentPostProcessor processor = new ConsulConfigDataMissingEnvironmentPostProcessor();
+		assertThatCode(() -> processor.postProcessEnvironment(environment, app)).doesNotThrowAnyException();
+	}
+
+	@Test
+	void importCheckNotEnabled() {
+		MockEnvironment environment = new MockEnvironment();
+		environment.setProperty("spring.cloud.consul.config.import-check.enabled", "false");
+		SpringApplication app = mock(SpringApplication.class);
+		ConsulConfigDataMissingEnvironmentPostProcessor processor = new ConsulConfigDataMissingEnvironmentPostProcessor();
+		assertThatCode(() -> processor.postProcessEnvironment(environment, app)).doesNotThrowAnyException();
+	}
+
+	@Test
+	void importSinglePropertySource() {
+		MockEnvironment environment = new MockEnvironment();
+		environment.setProperty("spring.config.import", "consul:http://localhost:8888");
+		SpringApplication app = mock(SpringApplication.class);
+		ConsulConfigDataMissingEnvironmentPostProcessor processor = new ConsulConfigDataMissingEnvironmentPostProcessor();
+		assertThatCode(() -> processor.postProcessEnvironment(environment, app)).doesNotThrowAnyException();
+	}
+
+	@Test
+	void importMultiplePropertySource() {
+		MockEnvironment environment = new MockEnvironment();
+		environment.setProperty("spring.config.import", "consul:http://localhost:8888,file:./app.properties");
+		SpringApplication app = mock(SpringApplication.class);
+		ConsulConfigDataMissingEnvironmentPostProcessor processor = new ConsulConfigDataMissingEnvironmentPostProcessor();
+		assertThatCode(() -> processor.postProcessEnvironment(environment, app)).doesNotThrowAnyException();
+	}
+
+	@Test
+	void importMultiplePropertySourceAsList() {
+		MockEnvironment environment = new MockEnvironment();
+		environment.setProperty("spring.config.import[0]", "consul:http://localhost:8888");
+		environment.setProperty("spring.config.import[1]", "file:./app.properties");
+		SpringApplication app = mock(SpringApplication.class);
+		ConsulConfigDataMissingEnvironmentPostProcessor processor = new ConsulConfigDataMissingEnvironmentPostProcessor();
+		assertThatCode(() -> processor.postProcessEnvironment(environment, app)).doesNotThrowAnyException();
+	}
+
+}

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigDataNoImportIntegrationTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigDataNoImportIntegrationTests.java
@@ -28,7 +28,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
-import org.springframework.cloud.consul.config.ConsulConfigDataMissingEnvironmentPostProcessor.ImportException;
+import org.springframework.cloud.commons.ConfigDataMissingEnvironmentPostProcessor;
 import org.springframework.cloud.consul.test.ConsulTestcontainers;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
@@ -63,7 +63,7 @@ public class ConsulConfigDataNoImportIntegrationTests {
 	@Test
 	public void exceptionThrownIfNoImport(CapturedOutput output) {
 		Assertions.assertThatThrownBy(() -> new SpringApplicationBuilder(Config.class).web(WebApplicationType.NONE)
-				.run("--spring.application.name=" + APP_NAME)).isInstanceOf(ImportException.class);
+				.run("--spring.application.name=" + APP_NAME)).isInstanceOf(ConfigDataMissingEnvironmentPostProcessor.ImportException.class);
 
 		assertThat(output).contains("No spring.config.import property has been defined")
 				.contains("Add a spring.config.import=consul: property to your configuration");
@@ -73,7 +73,7 @@ public class ConsulConfigDataNoImportIntegrationTests {
 	public void exceptionThrownIfImportMissingConsul(CapturedOutput output) {
 		Assertions.assertThatThrownBy(() -> new SpringApplicationBuilder(Config.class).web(WebApplicationType.NONE).run(
 				"--spring.config.import=optional:file:somefile.properties", "--spring.application.name=" + APP_NAME))
-				.isInstanceOf(ImportException.class);
+				.isInstanceOf(ConfigDataMissingEnvironmentPostProcessor.ImportException.class);
 
 		assertThat(output).contains("spring.config.import property is missing a " + PREFIX)
 				.contains("Add a spring.config.import=consul: property to your configuration");

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigDataNoImportIntegrationTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigDataNoImportIntegrationTests.java
@@ -62,8 +62,10 @@ public class ConsulConfigDataNoImportIntegrationTests {
 
 	@Test
 	public void exceptionThrownIfNoImport(CapturedOutput output) {
-		Assertions.assertThatThrownBy(() -> new SpringApplicationBuilder(Config.class).web(WebApplicationType.NONE)
-				.run("--spring.application.name=" + APP_NAME)).isInstanceOf(ConfigDataMissingEnvironmentPostProcessor.ImportException.class);
+		Assertions
+				.assertThatThrownBy(() -> new SpringApplicationBuilder(Config.class).web(WebApplicationType.NONE)
+						.run("--spring.application.name=" + APP_NAME))
+				.isInstanceOf(ConfigDataMissingEnvironmentPostProcessor.ImportException.class);
 
 		assertThat(output).contains("No spring.config.import property has been defined")
 				.contains("Add a spring.config.import=consul: property to your configuration");
@@ -71,8 +73,10 @@ public class ConsulConfigDataNoImportIntegrationTests {
 
 	@Test
 	public void exceptionThrownIfImportMissingConsul(CapturedOutput output) {
-		Assertions.assertThatThrownBy(() -> new SpringApplicationBuilder(Config.class).web(WebApplicationType.NONE).run(
-				"--spring.config.import=optional:file:somefile.properties", "--spring.application.name=" + APP_NAME))
+		Assertions
+				.assertThatThrownBy(() -> new SpringApplicationBuilder(Config.class).web(WebApplicationType.NONE).run(
+						"--spring.config.import=optional:file:somefile.properties",
+						"--spring.application.name=" + APP_NAME))
 				.isInstanceOf(ConfigDataMissingEnvironmentPostProcessor.ImportException.class);
 
 		assertThat(output).contains("spring.config.import property is missing a " + PREFIX)


### PR DESCRIPTION
Depends on https://github.com/spring-cloud/spring-cloud-commons/pull/936

Allows post processor to handle lists in `spring.config.import`.