### PR TITLE
ConsulPropertySourceLocator add shared contexts

### DIFF
--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
@@ -16,19 +16,20 @@
 
 package org.springframework.cloud.consul.config;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.util.CollectionUtils;
 import org.springframework.validation.annotation.Validated;
-
-import javax.annotation.PostConstruct;
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 import static org.springframework.cloud.consul.config.ConsulConfigProperties.PREFIX;
 
@@ -225,7 +226,7 @@ public class ConsulConfigProperties {
 	 * as whole configuration " a.b.c=something a.b.d=something else "</li>
 	 * <li>as Json or YML. You get it.</li>
 	 * </ol>
-	 * <p>
+	 *
 	 * This enum specifies the different Formats/styles supported for loading the
 	 * configuration.
 	 *
@@ -273,14 +274,10 @@ public class ConsulConfigProperties {
 		 */
 		private int waitTime = 55;
 
-		/**
-		 * If the watch is enabled. Defaults to true.
-		 */
+		/** If the watch is enabled. Defaults to true. */
 		private boolean enabled = true;
 
-		/**
-		 * The value of the fixed delay for the watch in millis. Defaults to 1000.
-		 */
+		/** The value of the fixed delay for the watch in millis. Defaults to 1000. */
 		private int delay = 1000;
 
 		public Watch() {

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
@@ -79,6 +79,9 @@ public class ConsulConfigProperties {
 	 */
 	private String name;
 
+	/**
+	 * contexts which shared with each other, lowest priority
+	 */
 	private String[] sharedContexts;
 
 	public ConsulConfigProperties() {

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
@@ -16,20 +16,19 @@
 
 package org.springframework.cloud.consul.config;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import javax.annotation.PostConstruct;
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.util.CollectionUtils;
 import org.springframework.validation.annotation.Validated;
+
+import javax.annotation.PostConstruct;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import static org.springframework.cloud.consul.config.ConsulConfigProperties.PREFIX;
 
@@ -80,6 +79,8 @@ public class ConsulConfigProperties {
 	 */
 	private String name;
 
+	private String[] sharedContexts;
+
 	public ConsulConfigProperties() {
 	}
 
@@ -107,7 +108,7 @@ public class ConsulConfigProperties {
 	}
 
 	@DeprecatedConfigurationProperty(reason = "replaced to support multiple prefixes",
-			replacement = PREFIX + ".prefixes")
+		replacement = PREFIX + ".prefixes")
 	public String getPrefix() {
 		if (CollectionUtils.isEmpty(this.prefixes)) {
 			return null;
@@ -119,8 +120,7 @@ public class ConsulConfigProperties {
 	public void setPrefix(String prefix) {
 		if (prefix != null) {
 			this.prefixes = new ArrayList<>(Collections.singletonList(prefix));
-		}
-		else {
+		} else {
 			this.prefixes = new ArrayList<>();
 		}
 	}
@@ -189,12 +189,22 @@ public class ConsulConfigProperties {
 		this.name = name;
 	}
 
+	public String[] getSharedContexts() {
+		return sharedContexts;
+	}
+
+	public void setSharedContexts(String[] sharedContexts) {
+		this.sharedContexts = sharedContexts;
+	}
+
 	@Override
 	public String toString() {
 		return new ToStringCreator(this).append("enabled", this.enabled).append("prefixes", this.prefixes)
-				.append("defaultContext", this.defaultContext).append("profileSeparator", this.profileSeparator)
-				.append("format", this.format).append("dataKey", this.dataKey).append("aclToken", this.aclToken)
-				.append("watch", this.watch).append("failFast", this.failFast).append("name", this.name).toString();
+			.append("defaultContext", this.defaultContext).append("profileSeparator", this.profileSeparator)
+			.append("format", this.format).append("dataKey", this.dataKey).append("aclToken", this.aclToken)
+			.append("watch", this.watch).append("failFast", this.failFast)
+			.append("name", this.name).append("sharedContexts", this.sharedContexts)
+			.toString();
 	}
 
 	/**
@@ -212,7 +222,7 @@ public class ConsulConfigProperties {
 	 * as whole configuration " a.b.c=something a.b.d=something else "</li>
 	 * <li>as Json or YML. You get it.</li>
 	 * </ol>
-	 *
+	 * <p>
 	 * This enum specifies the different Formats/styles supported for loading the
 	 * configuration.
 	 *
@@ -260,10 +270,14 @@ public class ConsulConfigProperties {
 		 */
 		private int waitTime = 55;
 
-		/** If the watch is enabled. Defaults to true. */
+		/**
+		 * If the watch is enabled. Defaults to true.
+		 */
 		private boolean enabled = true;
 
-		/** The value of the fixed delay for the watch in millis. Defaults to 1000. */
+		/**
+		 * The value of the fixed delay for the watch in millis. Defaults to 1000.
+		 */
 		private int delay = 1000;
 
 		public Watch() {
@@ -296,7 +310,7 @@ public class ConsulConfigProperties {
 		@Override
 		public String toString() {
 			return new ToStringCreator(this).append("waitTime", this.waitTime).append("enabled", this.enabled)
-					.append("delay", this.delay).toString();
+				.append("delay", this.delay).toString();
 		}
 
 	}

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
@@ -112,7 +112,7 @@ public class ConsulConfigProperties {
 	}
 
 	@DeprecatedConfigurationProperty(reason = "replaced to support multiple prefixes",
-		replacement = PREFIX + ".prefixes")
+			replacement = PREFIX + ".prefixes")
 	public String getPrefix() {
 		if (CollectionUtils.isEmpty(this.prefixes)) {
 			return null;
@@ -124,7 +124,8 @@ public class ConsulConfigProperties {
 	public void setPrefix(String prefix) {
 		if (prefix != null) {
 			this.prefixes = new ArrayList<>(Collections.singletonList(prefix));
-		} else {
+		}
+		else {
 			this.prefixes = new ArrayList<>();
 		}
 	}
@@ -310,7 +311,7 @@ public class ConsulConfigProperties {
 		@Override
 		public String toString() {
 			return new ToStringCreator(this).append("waitTime", this.waitTime).append("enabled", this.enabled)
-				.append("delay", this.delay).toString();
+					.append("delay", this.delay).toString();
 		}
 
 	}

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocator.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocator.java
@@ -25,6 +25,7 @@ import java.util.List;
 import com.ecwid.consul.v1.ConsulClient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.CompositePropertySource;
@@ -92,7 +93,7 @@ public class ConsulPropertySourceLocator implements PropertySourceLocator, Consu
 
 			for (String propertySourceContext : this.contexts) {
 				ConsulPropertySource propertySource = sources.createPropertySource(propertySourceContext, this.consul,
-					contextIndex::put);
+						contextIndex::put);
 				if (propertySource != null) {
 					composite.addPropertySource(propertySource);
 				}

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocator.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocator.java
@@ -16,6 +16,12 @@
 
 package org.springframework.cloud.consul.config;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+
 import com.ecwid.consul.v1.ConsulClient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -26,8 +32,6 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertySource;
 import org.springframework.retry.annotation.Retryable;
-
-import java.util.*;
 
 /**
  * @author Spencer Gibb

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySources.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySources.java
@@ -38,7 +38,7 @@ public class ConsulPropertySources {
 	protected static final List<String> DIR_SUFFIXES = Collections.singletonList("/");
 
 	protected static final List<String> FILES_SUFFIXES = Collections
-		.unmodifiableList(Arrays.asList(".yml", ".yaml", ".properties"));
+			.unmodifiableList(Arrays.asList(".yml", ".yaml", ".properties"));
 
 	private final ConsulConfigProperties properties;
 
@@ -97,7 +97,8 @@ public class ConsulPropertySources {
 	protected String getContext(String prefix, String context) {
 		if (!StringUtils.hasText(prefix)) {
 			return context;
-		} else {
+		}
+		else {
 			return prefix + "/" + context;
 		}
 	}
@@ -118,12 +119,12 @@ public class ConsulPropertySources {
 
 	@Deprecated
 	public ConsulPropertySource createPropertySource(String propertySourceContext, boolean optional,
-													 ConsulClient consul, BiConsumer<String, Long> indexConsumer) {
+			ConsulClient consul, BiConsumer<String, Long> indexConsumer) {
 		return createPropertySource(propertySourceContext, consul, indexConsumer);
 	}
 
 	public ConsulPropertySource createPropertySource(String propertySourceContext, ConsulClient consul,
-													 BiConsumer<String, Long> indexConsumer) {
+			BiConsumer<String, Long> indexConsumer) {
 		try {
 			ConsulPropertySource propertySource = null;
 
@@ -132,20 +133,24 @@ public class ConsulPropertySources {
 				indexConsumer.accept(propertySourceContext, response.getConsulIndex());
 				if (response.getValue() != null) {
 					ConsulFilesPropertySource filesPropertySource = new ConsulFilesPropertySource(propertySourceContext,
-						consul, properties);
+							consul, properties);
 					filesPropertySource.init(response.getValue());
 					propertySource = filesPropertySource;
 				}
-			} else {
+			}
+			else {
 				propertySource = create(propertySourceContext, consul, indexConsumer);
 			}
 			return propertySource;
-		} catch (PropertySourceNotFoundException e) {
+		}
+		catch (PropertySourceNotFoundException e) {
 			throw e;
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			if (properties.isFailFast()) {
 				throw new PropertySourceNotFoundException(propertySourceContext, e);
-			} else {
+			}
+			else {
 				log.warn("Unable to load consul config from " + propertySourceContext, e);
 			}
 		}
@@ -153,7 +158,7 @@ public class ConsulPropertySources {
 	}
 
 	private ConsulPropertySource create(String context, ConsulClient consulClient,
-										BiConsumer<String, Long> indexConsumer) {
+			BiConsumer<String, Long> indexConsumer) {
 		ConsulPropertySource propertySource = new ConsulPropertySource(context, consulClient, this.properties);
 		propertySource.init();
 		indexConsumer.accept(context, propertySource.getInitialIndex());

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySources.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySources.java
@@ -16,19 +16,20 @@
 
 package org.springframework.cloud.consul.config;
 
-import com.ecwid.consul.v1.ConsulClient;
-import com.ecwid.consul.v1.Response;
-import com.ecwid.consul.v1.kv.model.GetValue;
-import org.apache.commons.logging.Log;
-import org.springframework.core.style.ToStringCreator;
-import org.springframework.util.StringUtils;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.Response;
+import com.ecwid.consul.v1.kv.model.GetValue;
+import org.apache.commons.logging.Log;
+
+import org.springframework.core.style.ToStringCreator;
+import org.springframework.util.StringUtils;
 
 import static org.springframework.cloud.consul.config.ConsulConfigProperties.Format.FILES;
 


### PR DESCRIPTION
In my project, I need to load multiple public keys, for example:
```
/xxx/config/application
/xxx/config/public
/xxx/config/public.others
```
There is no suitable model at present，So I add a property `sharedContexts` to support
In addition, I decouple `ConsulPropertySources` from the `ConsulPropertySourceLocator`