### PR TITLE
refactor: remove `@RequestMapping` annotations

### DIFF
--- a/spring-cloud-consul-binder/src/test/java/org/springframework/cloud/consul/binder/test/consumer/TestConsumer.java
+++ b/spring-cloud-consul-binder/src/test/java/org/springframework/cloud/consul/binder/test/consumer/TestConsumer.java
@@ -35,7 +35,7 @@ import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.ExecutorSubscribableChannel;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -92,12 +92,12 @@ public class TestConsumer implements ApplicationRunner {
 		this.isBound = true;
 	}
 
-	@RequestMapping("/is-bound")
+	@GetMapping("/is-bound")
 	public boolean isBound() {
 		return this.isBound;
 	}
 
-	@RequestMapping("/message-payload")
+	@GetMapping("/message-payload")
 	public String getMessagePayload() {
 		return this.messagePayload;
 	}

--- a/spring-cloud-consul-binder/src/test/java/org/springframework/cloud/consul/binder/test/producer/TestProducer.java
+++ b/spring-cloud-consul-binder/src/test/java/org/springframework/cloud/consul/binder/test/producer/TestProducer.java
@@ -37,7 +37,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.ExecutorSubscribableChannel;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -86,7 +86,7 @@ public class TestProducer implements ApplicationRunner {
 		return new StubPartitionSelectorStrategy();
 	}
 
-	@RequestMapping("/partition-strategy-invoked")
+	@GetMapping("/partition-strategy-invoked")
 	public boolean partitionStrategyInvoked() {
 		return stubPartitionSelectorStrategy().invoked;
 	}

--- a/spring-cloud-consul-integration-tests/spring-cloud-consul-bootstrap-tests/src/main/java/org/springframework/cloud/consul/bootstraptests/ConsulBootstrapApplication.java
+++ b/spring-cloud-consul-integration-tests/spring-cloud-consul-bootstrap-tests/src/main/java/org/springframework/cloud/consul/bootstraptests/ConsulBootstrapApplication.java
@@ -35,8 +35,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
@@ -77,37 +76,37 @@ public class ConsulBootstrapApplication {
 		SpringApplication.run(ConsulBootstrapApplication.class, args);
 	}
 
-	@RequestMapping("/me")
+	@GetMapping("/me")
 	public ServiceInstance me() {
 		return this.registration;
 	}
 
-	@RequestMapping("/")
+	@GetMapping("/")
 	public ServiceInstance lb() {
 		return this.loadBalancer.choose(this.appName);
 	}
 
-	@RequestMapping("/rest")
+	@GetMapping("/rest")
 	public String rest() {
 		return this.restTemplate.getForObject("http://" + this.appName + "/me", String.class);
 	}
 
-	@RequestMapping("/choose")
+	@GetMapping("/choose")
 	public String choose() {
 		return this.loadBalancer.choose(this.appName).getUri().toString();
 	}
 
-	@RequestMapping("/myenv")
+	@GetMapping("/myenv")
 	public String env(@RequestParam("prop") String prop) {
 		return this.env.getProperty(prop, "Not Found");
 	}
 
-	@RequestMapping("/prop")
+	@GetMapping("/prop")
 	public String prop() {
 		return sampleProperties().getProp();
 	}
 
-	@RequestMapping("/instances")
+	@GetMapping("/instances")
 	public List<ServiceInstance> instances() {
 		return this.discoveryClient.getInstances(this.appName);
 	}
@@ -117,7 +116,7 @@ public class ConsulBootstrapApplication {
 	 * SubtypeModule(SimpleRemoteEvent.class); }
 	 */
 
-	@RequestMapping("/feign")
+	@GetMapping("/feign")
 	public String feign() {
 		return this.sampleClient.choose();
 	}
@@ -141,7 +140,7 @@ public class ConsulBootstrapApplication {
 	@FeignClient("testConsulApp")
 	public interface SampleClient {
 
-		@RequestMapping(value = "/choose", method = RequestMethod.GET)
+		@GetMapping("/choose")
 		String choose();
 
 	}


### PR DESCRIPTION
Co-authored-by: Moderne <team@moderne.io>

Just using the more specific HTTP verb annotations.