### PR TITLE
Support service discovery list backup. (#751)

### DIFF
--- a/spring-cloud-consul-core/src/test/java/org/springframework/cloud/consul/test/ConsulTestcontainers.java
+++ b/spring-cloud-consul-core/src/test/java/org/springframework/cloud/consul/test/ConsulTestcontainers.java
@@ -60,6 +60,10 @@ public class ConsulTestcontainers implements ApplicationContextInitializer<Confi
 		consul.start();
 	}
 
+	public static void stop() {
+		consul.stop();
+	}
+
 	public static Integer getPort() {
 		if (!consul.isRunning()) {
 			throw new IllegalStateException("consul Testcontainer is not running");

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryProperties.java
@@ -40,6 +40,7 @@ import org.springframework.util.StringUtils;
  * @author Donnabell Dmello
  * @author Venil Noronha
  * @author Richard Kettelerij
+ * @author Chen Zhiguo
  */
 @ConfigurationProperties(ConsulDiscoveryProperties.PREFIX)
 public class ConsulDiscoveryProperties {
@@ -211,6 +212,11 @@ public class ConsulDiscoveryProperties {
 	 * available clients.
 	 */
 	private int order = 0;
+
+	/**
+	 * Turn on the service list backup, use backup data when consul is not available.
+	 */
+	private boolean backup = false;
 
 	@SuppressWarnings("unused")
 	private ConsulDiscoveryProperties() {
@@ -617,6 +623,14 @@ public class ConsulDiscoveryProperties {
 		this.managementEnableTagOverride = managementEnableTagOverride;
 	}
 
+	public boolean isBackup() {
+		return backup;
+	}
+
+	public void setBackup(boolean backup) {
+		this.backup = backup;
+	}
+
 	@Override
 	public String toString() {
 		return new ToStringCreator(this).append("aclToken", this.aclToken)
@@ -645,7 +659,8 @@ public class ConsulDiscoveryProperties {
 				.append("queryPassing", this.queryPassing).append("register", this.register)
 				.append("registerHealthCheck", this.registerHealthCheck).append("scheme", this.scheme)
 				.append("serviceName", this.serviceName).append("serverListQueryTags", this.serverListQueryTags)
-				.append("tags", this.tags).toString();
+				.append("tags", this.tags)
+			    .append("backup", this.backup).toString();
 	}
 
 	/**

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClientTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClientTests.java
@@ -40,6 +40,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 /**
  * @author Spencer Gibb
  * @author Joe Athman
+ * @author Chen Zhiguo
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(properties = { "spring.application.name=testConsulDiscovery",
@@ -53,6 +54,9 @@ public class ConsulDiscoveryClientTests {
 
 	@Autowired
 	private ConsulClient consulClient;
+
+	@Autowired
+	private ConsulDiscoveryProperties properties;
 
 	@Test
 	public void getInstancesForServiceWorks() {
@@ -78,6 +82,19 @@ public class ConsulDiscoveryClientTests {
 
 		ServiceInstance instance = instances.get(0);
 		assertIpAddress(instance);
+	}
+
+	@Test
+	public void getInstancesFromBackup() {
+		properties.setBackup(true);
+		List<ServiceInstance> instances = this.discoveryClient.getInstances("testConsulDiscovery");
+		assertThat(instances.isEmpty()).as("instances was empty").isFalse();
+		// Close consul container
+		ConsulTestcontainers.stop();
+		List<ServiceInstance> backupInstances = this.discoveryClient.getInstances("testConsulDiscovery");
+		assertThat(backupInstances.isEmpty()).as("instances was empty").isFalse();
+		// Resume consul container
+		ConsulTestcontainers.start();
 	}
 
 	@Test

--- a/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryPropertiesTests.java
+++ b/spring-cloud-consul-discovery/src/test/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryPropertiesTests.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Unit tests for {@link ConsulDiscoveryProperties}.
  *
  * @author Chris Bono
+ * @author Chen Zhiguo
  */
 class ConsulDiscoveryPropertiesTests {
 
@@ -140,6 +141,12 @@ class ConsulDiscoveryPropertiesTests {
 	void addManagementTag() {
 		properties.getManagementTags().add("newTag");
 		assertThat(properties.getManagementTags()).containsOnly(ConsulDiscoveryProperties.MANAGEMENT, "newTag");
+	}
+
+	@Test
+	void setBackup() {
+		properties.setBackup(true);
+		assertThat(properties.isBackup()).isEqualTo(true);
 	}
 
 }


### PR DESCRIPTION
Cache the service list data, if the Consul cluster is not available, use cache data to ensure that the service is highly available.