### PR TITLE
Modify LogFactory Input parameter of getlog

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulCatalogWatch.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulCatalogWatch.java
@@ -43,7 +43,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
  */
 public class ConsulCatalogWatch implements ApplicationEventPublisherAware, SmartLifecycle {
 
-	private static final Log log = LogFactory.getLog(ConsulDiscoveryClient.class);
+	private static final Log log = LogFactory.getLog(ConsulCatalogWatch.class);
 
 	private final ConsulDiscoveryProperties properties;
 

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/TtlScheduler.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/TtlScheduler.java
@@ -37,7 +37,7 @@ import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
  */
 public class TtlScheduler {
 
-	private static final Log log = LogFactory.getLog(ConsulDiscoveryClient.class);
+	private static final Log log = LogFactory.getLog(TtlScheduler.class);
 
 	private final Map<String, ScheduledFuture> serviceHeartbeats = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
When I read the source code of spring cloud consult, I found the LogFactory of ConsulCatalogWatch and TtlScheduler The input parameters of getLog are not written correctly. Of course, this is only a small problem and does not affect the operation of the code