### PR TITLE
Fixed the problem of creating ConsulServiceInstance

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/reactive/ConsulReactiveDiscoveryClient.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/reactive/ConsulReactiveDiscoveryClient.java
@@ -16,25 +16,26 @@
 
 package org.springframework.cloud.consul.discovery.reactive;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 import com.ecwid.consul.v1.ConsulClient;
 import com.ecwid.consul.v1.QueryParams;
 import com.ecwid.consul.v1.Response;
 import com.ecwid.consul.v1.catalog.CatalogServicesRequest;
 import com.ecwid.consul.v1.health.HealthServicesRequest;
 import com.ecwid.consul.v1.health.model.HealthService;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import static java.util.stream.Collectors.toList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.ReactiveDiscoveryClient;
 import org.springframework.cloud.consul.discovery.ConsulDiscoveryProperties;
 import org.springframework.cloud.consul.discovery.ConsulServiceInstance;
-import reactor.core.publisher.Flux;
-import reactor.core.scheduler.Schedulers;
 
 /**
  * Consul version of {@link ReactiveDiscoveryClient}.


### PR DESCRIPTION
When I registered a "myApp" service on consumer, because I didn't set the port number, spring cloud consumer discovery threw a NullPointerException when reading the service and creating a DefaultServiceInstance. Later, I found that it was because the port of the DefaultServiceInstance constructor was of type "int" rather than "Integer", so when our port was null, the reading of the service would fail, Therefore, I think spring cloud consumer discovery should filter out such illegal instances and ensure that other instances of the service are still read successfully.

Here I attach the exception stack information:

```
java.lang.NullPointerException: null
	at org.springframework.cloud.consul.discovery.ConsulServiceInstance.<init>(ConsulServiceInstance.java:37) ~[spring-cloud-consul-discovery-3.0.4.jar:3.0.4]
	at org.springframework.cloud.consul.discovery.reactive.ConsulReactiveDiscoveryClient.lambda$getInstances$0(ConsulReactiveDiscoveryClient.java:69) ~[spring-cloud-consul-discovery-3.0.4.jar:3.0.4]
	at reactor.core.publisher.FluxDefer.subscribe(FluxDefer.java:46) ~[reactor-core-3.4.14.jar:3.4.14]
```

Here is also a screenshot of the Consul service registration:
![image](https://user-images.githubusercontent.com/6687462/159212326-f3c93388-7530-44a8-a4f9-df7fb34a2cd7.png)

![image](https://user-images.githubusercontent.com/6687462/159212313-dd24b79c-43a5-433c-b282-addc0885d6dc.png)
