### PR TITLE
Extract consul client builder to distinct bean

### DIFF
--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigDataLocationResolver.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigDataLocationResolver.java
@@ -184,7 +184,8 @@ public class ConsulConfigDataLocationResolver implements ConfigDataLocationResol
 	protected ConsulClient createConsulClient(BootstrapContext context) {
 		ConsulProperties properties = context.get(ConsulProperties.class);
 
-		return ConsulAutoConfiguration.createConsulClient(properties);
+		return ConsulAutoConfiguration.createConsulClient(properties,
+				ConsulAutoConfiguration.createConsulRawClientBuilder());
 	}
 
 	protected ConsulProperties loadProperties(ConfigDataLocationResolverContext resolverContext,

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulAutoConfiguration.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulAutoConfiguration.java
@@ -55,18 +55,18 @@ public class ConsulAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public Supplier<ConsulRawClient.Builder> consulRawClientBuilder() {
+	public Supplier<ConsulRawClient.Builder> consulRawClientBuilderSupplier() {
 		return () -> ConsulRawClient.Builder.builder();
 	}
 
 	@Bean
 	@ConditionalOnMissingBean
-	public ConsulClient consulClient(ConsulProperties consulProperties, Supplier<ConsulRawClient.Builder> builderSupplier) {
-		return createConsulClient(consulProperties, builderSupplier);
+	public ConsulClient consulClient(ConsulProperties consulProperties, Supplier<ConsulRawClient.Builder> consulRawClientBuilderSupplier) {
+		return createConsulClient(consulProperties, consulRawClientBuilderSupplier);
 	}
 
-	public static ConsulClient createConsulClient(ConsulProperties consulProperties, Supplier<ConsulRawClient.Builder> builderSupplier) {
-		ConsulRawClient.Builder builder = builderSupplier.get();
+	public static ConsulClient createConsulClient(ConsulProperties consulProperties, Supplier<ConsulRawClient.Builder> consulRawClientBuilderSupplier) {
+		ConsulRawClient.Builder builder = consulRawClientBuilderSupplier.get();
 		final String agentPath = consulProperties.getPath();
 		final String agentHost = StringUtils.hasLength(consulProperties.getScheme())
 				? consulProperties.getScheme() + "://" + consulProperties.getHost() : consulProperties.getHost();

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulAutoConfiguration.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulAutoConfiguration.java
@@ -16,10 +16,11 @@
 
 package org.springframework.cloud.consul;
 
+import java.util.function.Supplier;
+
 import com.ecwid.consul.transport.TLSConfig;
 import com.ecwid.consul.v1.ConsulClient;
 import com.ecwid.consul.v1.ConsulRawClient;
-import java.util.function.Supplier;
 import org.aspectj.lang.annotation.Aspect;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
@@ -61,11 +62,13 @@ public class ConsulAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public ConsulClient consulClient(ConsulProperties consulProperties, Supplier<ConsulRawClient.Builder> consulRawClientBuilderSupplier) {
+	public ConsulClient consulClient(ConsulProperties consulProperties,
+			Supplier<ConsulRawClient.Builder> consulRawClientBuilderSupplier) {
 		return createConsulClient(consulProperties, consulRawClientBuilderSupplier);
 	}
 
-	public static ConsulClient createConsulClient(ConsulProperties consulProperties, Supplier<ConsulRawClient.Builder> consulRawClientBuilderSupplier) {
+	public static ConsulClient createConsulClient(ConsulProperties consulProperties,
+			Supplier<ConsulRawClient.Builder> consulRawClientBuilderSupplier) {
 		ConsulRawClient.Builder builder = consulRawClientBuilderSupplier.get();
 		final String agentPath = consulProperties.getPath();
 		final String agentHost = StringUtils.hasLength(consulProperties.getScheme())

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulAutoConfiguration.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulAutoConfiguration.java
@@ -54,16 +54,21 @@ public class ConsulAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public ConsulClient consulClient(ConsulProperties consulProperties) {
-		return createConsulClient(consulProperties);
+	public ConsulRawClient.Builder consulRawClientBuilder() {
+		return ConsulRawClient.Builder.builder();
 	}
 
-	public static ConsulClient createConsulClient(ConsulProperties consulProperties) {
+	@Bean
+	@ConditionalOnMissingBean
+	public ConsulClient consulClient(ConsulProperties consulProperties, ConsulRawClient.Builder builder) {
+		return createConsulClient(consulProperties, builder);
+	}
+
+	public static ConsulClient createConsulClient(ConsulProperties consulProperties, ConsulRawClient.Builder builder) {
 		final String agentPath = consulProperties.getPath();
 		final String agentHost = StringUtils.hasLength(consulProperties.getScheme())
 				? consulProperties.getScheme() + "://" + consulProperties.getHost() : consulProperties.getHost();
-		final ConsulRawClient.Builder builder = ConsulRawClient.Builder.builder().setHost(agentHost)
-				.setPort(consulProperties.getPort());
+		builder.setHost(agentHost).setPort(consulProperties.getPort());
 
 		if (consulProperties.getTls() != null) {
 			ConsulProperties.TLSConfig tls = consulProperties.getTls();

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulAutoConfiguration.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.consul;
 import com.ecwid.consul.transport.TLSConfig;
 import com.ecwid.consul.v1.ConsulClient;
 import com.ecwid.consul.v1.ConsulRawClient;
+import java.util.function.Supplier;
 import org.aspectj.lang.annotation.Aspect;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
@@ -54,17 +55,18 @@ public class ConsulAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public ConsulRawClient.Builder consulRawClientBuilder() {
-		return ConsulRawClient.Builder.builder();
+	public Supplier<ConsulRawClient.Builder> consulRawClientBuilder() {
+		return () -> ConsulRawClient.Builder.builder();
 	}
 
 	@Bean
 	@ConditionalOnMissingBean
-	public ConsulClient consulClient(ConsulProperties consulProperties, ConsulRawClient.Builder builder) {
-		return createConsulClient(consulProperties, builder);
+	public ConsulClient consulClient(ConsulProperties consulProperties, Supplier<ConsulRawClient.Builder> builderSupplier) {
+		return createConsulClient(consulProperties, builderSupplier);
 	}
 
-	public static ConsulClient createConsulClient(ConsulProperties consulProperties, ConsulRawClient.Builder builder) {
+	public static ConsulClient createConsulClient(ConsulProperties consulProperties, Supplier<ConsulRawClient.Builder> builderSupplier) {
+		ConsulRawClient.Builder builder = builderSupplier.get();
 		final String agentPath = consulProperties.getPath();
 		final String agentHost = StringUtils.hasLength(consulProperties.getScheme())
 				? consulProperties.getScheme() + "://" + consulProperties.getHost() : consulProperties.getHost();

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulAutoConfiguration.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulAutoConfiguration.java
@@ -21,6 +21,7 @@ import java.util.function.Supplier;
 import com.ecwid.consul.transport.TLSConfig;
 import com.ecwid.consul.v1.ConsulClient;
 import com.ecwid.consul.v1.ConsulRawClient;
+import com.ecwid.consul.v1.ConsulRawClient.Builder;
 import org.aspectj.lang.annotation.Aspect;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
@@ -57,7 +58,7 @@ public class ConsulAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public Supplier<ConsulRawClient.Builder> consulRawClientBuilderSupplier() {
-		return () -> ConsulRawClient.Builder.builder();
+		return createConsulRawClientBuilder();
 	}
 
 	@Bean
@@ -65,6 +66,10 @@ public class ConsulAutoConfiguration {
 	public ConsulClient consulClient(ConsulProperties consulProperties,
 			Supplier<ConsulRawClient.Builder> consulRawClientBuilderSupplier) {
 		return createConsulClient(consulProperties, consulRawClientBuilderSupplier);
+	}
+
+	public static Supplier<Builder> createConsulRawClientBuilder() {
+		return Builder::builder;
 	}
 
 	public static ConsulClient createConsulClient(ConsulProperties consulProperties,

--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/configclient/ConsulConfigServerBootstrapper.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/configclient/ConsulConfigServerBootstrapper.java
@@ -59,7 +59,8 @@ public class ConsulConfigServerBootstrapper implements BootstrapRegistryInitiali
 				return null;
 			}
 			ConsulProperties consulProperties = context.get(ConsulProperties.class);
-			return ConsulAutoConfiguration.createConsulClient(consulProperties);
+			return ConsulAutoConfiguration.createConsulClient(consulProperties,
+					ConsulAutoConfiguration.createConsulRawClientBuilder());
 		});
 		registry.registerIfAbsent(ConsulDiscoveryClient.class, context -> {
 			Binder binder = context.get(Binder.class);


### PR DESCRIPTION
Users of spring cloud consul may wish to further modify the consul client

Example modifications:
- Custom SSL config
- Adding interceptors to the HTTP client
- Additional logging etc.

Today the builder is statically instantiated inside createConsulClient() therefore any modifications will require the user to copy and paste the boilerplate setup in createConsulClient(), then make modifications.

Extracting the client builder out to a separate bean allows a custom builder to be injected and therefore any modifications can be made without  copy and pasting boilerplate code