### PR TITLE
Fix ipv6 formatting for consul discovery 

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServerUtils.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulServerUtils.java
@@ -55,7 +55,7 @@ public final class ConsulServerUtils {
 		try {
 			InetAddress inetAdr = InetAddress.getByName(address);
 			if (inetAdr instanceof Inet6Address) {
-				return "[" + inetAdr.getHostName() + "]";
+				return "[" + inetAdr.getHostAddress() + "]";
 			}
 			return address;
 		}


### PR DESCRIPTION
### In some specific scenario[IPV6 only], when reverse lookup from nameServer, will get domain other than ipv6 address. 

When wrap with square brackets, will result in `java.net.URISyntaxException: Malformed IPv6 address at index 8: http://[dc53-xx-xxxx-xxxx.example.org]:9209/xxx`

e.g.
<img width="592" alt="image" src="https://user-images.githubusercontent.com/13828239/213079862-f042509a-0f35-47a0-8b4e-b7e804d5b0df.png">
