### PR TITLE
Added status code 404 to ReregistrationPredicate

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ReregistrationPredicate.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ReregistrationPredicate.java
@@ -33,8 +33,8 @@ public interface ReregistrationPredicate {
 	boolean isEligible(OperationException e);
 
 	/**
-	 * Default implementation that performs re-registration when the status code is 500.
+	 * Default implementation that performs re-registration when the status code is either 404 or 500.
 	 */
-	ReregistrationPredicate DEFAULT = e -> e.getStatusCode() == 500;
+	ReregistrationPredicate DEFAULT = e -> (e.getStatusCode() == 404 || e.getStatusCode() == 500);
 
 }


### PR DESCRIPTION
Consul agent as of approximately v1.11.2 returns status code 404 on agent health check instead of status code 500. This change resulted in re-registration not taking place when expected. Adding status code 404 to the ReregistrationPredicate enables re-registration with both older and newer versions of Consul agent.