### PR TITLE
Properly resolve services using `datacenters` map

### DIFF
--- a/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClient.java
+++ b/spring-cloud-consul-discovery/src/main/java/org/springframework/cloud/consul/discovery/ConsulDiscoveryClient.java
@@ -54,7 +54,8 @@ public class ConsulDiscoveryClient implements DiscoveryClient {
 
 	@Override
 	public List<ServiceInstance> getInstances(final String serviceId) {
-		return getInstances(serviceId, new QueryParams(this.properties.getConsistencyMode()));
+		return getInstances(serviceId,
+				new QueryParams(this.properties.getDatacenters().get(serviceId), this.properties.getConsistencyMode()));
 	}
 
 	public List<ServiceInstance> getInstances(final String serviceId, final QueryParams queryParams) {


### PR DESCRIPTION
Support was introduced in 7a21240a82515f284f46fc2040d6731746e8ad9e but dropped later, the [docs](https://github.com/spring-cloud/spring-cloud-consul/blame/e46358b089737eec4b5c8c2265b9f86217b8c92b/docs/src/main/asciidoc/spring-cloud-consul.adoc#L376) still say this is supported, so this fixes this regression. Fixes #712