### PR TITLE
Replace Consul HTTP Client with Interface Clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<spring-cloud-deployer.version>2.8.3</spring-cloud-deployer.version>
 		<spring-cloud-openfeign.version>4.1.4-SNAPSHOT</spring-cloud-openfeign.version>
 		<spring-cloud-stream.version>4.1.4-SNAPSHOT</spring-cloud-stream.version>
-		<testcontainers.version>1.17.6</testcontainers.version>
+		<testcontainers.version>1.20.1</testcontainers.version>
 		<mockserverclient.version>5.15.0</mockserverclient.version>
 	</properties>
 

--- a/spring-cloud-consul-binder/pom.xml
+++ b/spring-cloud-consul-binder/pom.xml
@@ -32,11 +32,6 @@
 			<artifactId>spring-cloud-stream</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.ecwid.consul</groupId>
-			<artifactId>consul-api</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-consul-binder/src/main/java/org/springframework/cloud/consul/binder/ConsulInboundMessageProducer.java
+++ b/spring-cloud-consul-binder/src/main/java/org/springframework/cloud/consul/binder/ConsulInboundMessageProducer.java
@@ -22,7 +22,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import com.ecwid.consul.v1.OperationException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -102,11 +101,6 @@ public class ConsulInboundMessageProducer extends MessageProducerSupport {
 				sendMessage(getMessageBuilderFactory().withPayload(decoded)
 					// TODO: support headers
 					.build());
-			}
-		}
-		catch (OperationException e) {
-			if (logger.isErrorEnabled()) {
-				logger.error("Error getting consul events: " + e);
 			}
 		}
 		catch (Exception e) {

--- a/spring-cloud-consul-binder/src/main/java/org/springframework/cloud/consul/binder/ConsulInboundMessageProducer.java
+++ b/spring-cloud-consul-binder/src/main/java/org/springframework/cloud/consul/binder/ConsulInboundMessageProducer.java
@@ -23,10 +23,10 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import com.ecwid.consul.v1.OperationException;
-import com.ecwid.consul.v1.event.model.Event;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.cloud.consul.model.http.event.Event;
 import org.springframework.integration.endpoint.MessageProducerSupport;
 
 import static org.springframework.util.Base64Utils.decodeFromString;

--- a/spring-cloud-consul-binder/src/main/java/org/springframework/cloud/consul/binder/ConsulSendingHandler.java
+++ b/spring-cloud-consul-binder/src/main/java/org/springframework/cloud/consul/binder/ConsulSendingHandler.java
@@ -18,12 +18,9 @@ package org.springframework.cloud.consul.binder;
 
 import java.util.Arrays;
 
-import com.ecwid.consul.v1.ConsulClient;
-import com.ecwid.consul.v1.QueryParams;
-import com.ecwid.consul.v1.Response;
-import com.ecwid.consul.v1.event.model.Event;
-import com.ecwid.consul.v1.event.model.EventParams;
-
+import org.springframework.cloud.consul.IConsulClient;
+import org.springframework.cloud.consul.model.http.event.Event;
+import org.springframework.http.ResponseEntity;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.messaging.Message;
 
@@ -34,11 +31,11 @@ import org.springframework.messaging.Message;
  */
 public class ConsulSendingHandler extends AbstractMessageHandler {
 
-	private final ConsulClient consul;
+	private final IConsulClient consul;
 
 	private final String eventName;
 
-	public ConsulSendingHandler(ConsulClient consul, String eventName) {
+	public ConsulSendingHandler(IConsulClient consul, String eventName) {
 		this.consul = consul;
 		this.eventName = eventName;
 	}
@@ -56,8 +53,7 @@ public class ConsulSendingHandler extends AbstractMessageHandler {
 
 		// TODO: support headers
 		// TODO: support consul event filters: NodeFilter, ServiceFilter, TagFilter
-		Response<Event> event = this.consul.eventFire(this.eventName, (String) payload, new EventParams(),
-				QueryParams.DEFAULT);
+		ResponseEntity<Event> event = this.consul.eventFire(this.eventName, (String) payload);
 		// TODO: return event?
 	}
 

--- a/spring-cloud-consul-binder/src/main/java/org/springframework/cloud/consul/binder/config/ConsulBinderConfiguration.java
+++ b/spring-cloud-consul-binder/src/main/java/org/springframework/cloud/consul/binder/config/ConsulBinderConfiguration.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.consul.binder.config;
 
-import com.ecwid.consul.v1.ConsulClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +23,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.cloud.consul.ConditionalOnConsulEnabled;
+import org.springframework.cloud.consul.IConsulClient;
 import org.springframework.cloud.consul.binder.ConsulBinder;
 import org.springframework.cloud.consul.binder.EventService;
 import org.springframework.cloud.stream.binder.Binder;
@@ -52,7 +52,7 @@ public class ConsulBinderConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public EventService eventService(ConsulClient consulClient) {
+	public EventService eventService(IConsulClient consulClient) {
 		return new EventService(null/* consulBinderProperties */, consulClient, this.objectMapper);
 	}
 

--- a/spring-cloud-consul-binder/src/test/java/org/springframework/cloud/consul/binder/ConsulBinderApplicationTests.java
+++ b/spring-cloud-consul-binder/src/test/java/org/springframework/cloud/consul/binder/ConsulBinderApplicationTests.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.consul.binder;
 
 import java.util.concurrent.TimeUnit;
 
-import com.ecwid.consul.v1.ConsulClient;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -29,6 +28,9 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.consul.ConsulAutoConfiguration;
+import org.springframework.cloud.consul.ConsulProperties;
+import org.springframework.cloud.consul.IConsulClient;
 import org.springframework.cloud.consul.test.ConsulTestcontainers;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -112,12 +114,15 @@ public class ConsulBinderApplicationTests {
 	public static class Application {
 
 		@Bean
-		public ConsulClient consulClient() {
-			return new ConsulClient("localhost", 18500);
+		public IConsulClient consulClient() {
+			ConsulProperties consulProperties = new ConsulProperties();
+			consulProperties.setHost("localhost");
+			consulProperties.setPort(18500);
+			return ConsulAutoConfiguration.createNewConsulClient(consulProperties);
 		}
 
 		@Bean
-		public EventService eventService(ConsulClient consulClient) {
+		public EventService eventService(IConsulClient consulClient) {
 			EventService eventService = mock(EventService.class);
 			when(eventService.getConsulClient()).thenReturn(consulClient);
 			return eventService;

--- a/spring-cloud-consul-binder/src/test/java/org/springframework/cloud/consul/binder/ConsulInboundMessageProducerTests.java
+++ b/spring-cloud-consul-binder/src/test/java/org/springframework/cloud/consul/binder/ConsulInboundMessageProducerTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.consul.binder;
 
-import com.ecwid.consul.v1.OperationException;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.fail;
@@ -31,7 +30,7 @@ public class ConsulInboundMessageProducerTests {
 	@Test
 	public void getEventsShouldNotThrowException() {
 		EventService eventService = mock(EventService.class);
-		when(eventService.watch()).thenThrow(new OperationException(500, "error", ""));
+		when(eventService.watch()).thenThrow(new RuntimeException("error"));
 
 		ConsulInboundMessageProducer producer = new ConsulInboundMessageProducer(eventService);
 

--- a/spring-cloud-consul-config/pom.xml
+++ b/spring-cloud-consul-config/pom.xml
@@ -37,11 +37,6 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.ecwid.consul</groupId>
-			<artifactId>consul-api</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-consul-core</artifactId>
 			<optional>true</optional>
@@ -80,6 +75,11 @@
 		<dependency>
 			<groupId>org.junit.vintage</groupId>
 			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.ecwid.consul</groupId>
+			<artifactId>consul-api</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulBootstrapper.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulBootstrapper.java
@@ -19,8 +19,6 @@ package org.springframework.cloud.consul.config;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import com.ecwid.consul.v1.ConsulClient;
-
 import org.springframework.boot.BootstrapContext;
 import org.springframework.boot.BootstrapRegistry;
 import org.springframework.boot.BootstrapRegistryInitializer;
@@ -28,23 +26,24 @@ import org.springframework.boot.context.config.ConfigData;
 import org.springframework.boot.context.config.ConfigDataLoaderContext;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.cloud.consul.ConsulProperties;
+import org.springframework.cloud.consul.IConsulClient;
 import org.springframework.util.Assert;
 
 public class ConsulBootstrapper implements BootstrapRegistryInitializer {
 
-	private Function<BootstrapContext, ConsulClient> consulClientFactory;
+	private Function<BootstrapContext, IConsulClient> consulClientFactory;
 
 	private LoaderInterceptor loaderInterceptor;
 
-	static BootstrapRegistryInitializer fromConsulProperties(Function<ConsulProperties, ConsulClient> factory) {
-		return registry -> registry.register(ConsulClient.class, context -> {
+	static BootstrapRegistryInitializer fromConsulProperties(Function<ConsulProperties, IConsulClient> factory) {
+		return registry -> registry.register(IConsulClient.class, context -> {
 			ConsulProperties properties = context.get(ConsulProperties.class);
 			return factory.apply(properties);
 		});
 	}
 
-	static BootstrapRegistryInitializer fromBootstrapContext(Function<BootstrapContext, ConsulClient> factory) {
-		return registry -> registry.register(ConsulClient.class, factory::apply);
+	static BootstrapRegistryInitializer fromBootstrapContext(Function<BootstrapContext, IConsulClient> factory) {
+		return registry -> registry.register(IConsulClient.class, factory::apply);
 	}
 
 	static ConsulBootstrapper create() {
@@ -52,7 +51,7 @@ public class ConsulBootstrapper implements BootstrapRegistryInitializer {
 	}
 
 	// TODO: document there will be a ConsulProperties in BootstrapContext
-	public ConsulBootstrapper withConsulClientFactory(Function<BootstrapContext, ConsulClient> consulClientFactory) {
+	public ConsulBootstrapper withConsulClientFactory(Function<BootstrapContext, IConsulClient> consulClientFactory) {
 		this.consulClientFactory = consulClientFactory;
 		return this;
 	}
@@ -65,7 +64,7 @@ public class ConsulBootstrapper implements BootstrapRegistryInitializer {
 	@Override
 	public void initialize(BootstrapRegistry registry) {
 		if (consulClientFactory != null) {
-			registry.register(ConsulClient.class, consulClientFactory::apply);
+			registry.register(IConsulClient.class, consulClientFactory::apply);
 		}
 		if (loaderInterceptor != null) {
 			registry.register(LoaderInterceptor.class, BootstrapRegistry.InstanceSupplier.of(loaderInterceptor));

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigAutoConfiguration.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigAutoConfiguration.java
@@ -16,14 +16,13 @@
 
 package org.springframework.cloud.consul.config;
 
-import com.ecwid.consul.v1.ConsulClient;
-
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.consul.ConditionalOnConsulEnabled;
+import org.springframework.cloud.consul.IConsulClient;
 import org.springframework.cloud.endpoint.RefreshEndpoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -52,7 +51,7 @@ public class ConsulConfigAutoConfiguration {
 		@Bean
 		@ConditionalOnBean(ConsulConfigIndexes.class)
 		public ConfigWatch configWatch(ConsulConfigProperties properties, ConsulConfigIndexes indexes,
-				ConsulClient consul, @Qualifier(CONFIG_WATCH_TASK_SCHEDULER_NAME) TaskScheduler taskScheduler) {
+				IConsulClient consul, @Qualifier(CONFIG_WATCH_TASK_SCHEDULER_NAME) TaskScheduler taskScheduler) {
 			return new ConfigWatch(properties, consul, indexes.getIndexes(), taskScheduler);
 		}
 

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigBootstrapConfiguration.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigBootstrapConfiguration.java
@@ -16,14 +16,12 @@
 
 package org.springframework.cloud.consul.config;
 
-import com.ecwid.consul.v1.ConsulClient;
-
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.consul.ConditionalOnConsulEnabled;
 import org.springframework.cloud.consul.ConsulAutoConfiguration;
+import org.springframework.cloud.consul.IConsulClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -44,8 +42,11 @@ public class ConsulConfigBootstrapConfiguration {
 	@ConditionalOnProperty(name = "spring.cloud.consul.config.enabled", matchIfMissing = true)
 	protected static class ConsulPropertySourceConfiguration {
 
-		@Autowired
-		private ConsulClient consul;
+		private IConsulClient consul;
+
+		public ConsulPropertySourceConfiguration(IConsulClient consul) {
+			this.consul = consul;
+		}
 
 		@Bean
 		@ConditionalOnMissingBean

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigDataLoader.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigDataLoader.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
-import com.ecwid.consul.v1.ConsulClient;
 import org.apache.commons.logging.Log;
 
 import org.springframework.boot.context.config.ConfigData;
@@ -32,6 +31,7 @@ import org.springframework.boot.context.config.ConfigDataLoaderContext;
 import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.logging.DeferredLogFactory;
+import org.springframework.cloud.consul.IConsulClient;
 import org.springframework.cloud.consul.config.ConsulBootstrapper.LoadContext;
 import org.springframework.cloud.consul.config.ConsulBootstrapper.LoaderInterceptor;
 import org.springframework.util.StringUtils;
@@ -60,7 +60,7 @@ public class ConsulConfigDataLoader implements ConfigDataLoader<ConsulConfigData
 
 	public ConfigData doLoad(ConfigDataLoaderContext context, ConsulConfigDataResource resource) {
 		try {
-			ConsulClient consul = getBean(context, ConsulClient.class);
+			IConsulClient consul = getBean(context, IConsulClient.class);
 			ConsulConfigIndexes indexes = getBean(context, ConsulConfigIndexes.class);
 
 			ConsulPropertySource propertySource = resource.getConsulPropertySources()

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigDataLocationResolver.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigDataLocationResolver.java
@@ -23,7 +23,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.ecwid.consul.v1.ConsulClient;
 import org.apache.commons.logging.Log;
 
 import org.springframework.boot.BootstrapContext;
@@ -40,6 +39,7 @@ import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.logging.DeferredLogFactory;
 import org.springframework.cloud.consul.ConsulAutoConfiguration;
 import org.springframework.cloud.consul.ConsulProperties;
+import org.springframework.cloud.consul.IConsulClient;
 import org.springframework.cloud.consul.config.ConsulPropertySources.Context;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.lang.Nullable;
@@ -95,7 +95,7 @@ public class ConsulConfigDataLocationResolver implements ConfigDataLocationResol
 		// create consul client
 		registerBean(resolverContext, ConsulProperties.class, loadProperties(resolverContext, locationUri));
 
-		registerAndPromoteBean(resolverContext, ConsulClient.class, this::createConsulClient);
+		registerAndPromoteBean(resolverContext, IConsulClient.class, this::createConsulClient);
 
 		// create locations
 		ConsulConfigProperties properties = loadConfigProperties(resolverContext);
@@ -182,11 +182,10 @@ public class ConsulConfigDataLocationResolver implements ConfigDataLocationResol
 		bootstrapContext.registerIfAbsent(type, supplier);
 	}
 
-	protected ConsulClient createConsulClient(BootstrapContext context) {
+	protected IConsulClient createConsulClient(BootstrapContext context) {
 		ConsulProperties properties = context.get(ConsulProperties.class);
 
-		return ConsulAutoConfiguration.createConsulClient(properties,
-				ConsulAutoConfiguration.createConsulRawClientBuilder());
+		return ConsulAutoConfiguration.createNewConsulClient(properties);
 	}
 
 	protected ConsulProperties loadProperties(ConfigDataLocationResolverContext resolverContext,

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulFilesPropertySource.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulFilesPropertySource.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.consul.config;
 
-import com.ecwid.consul.v1.ConsulClient;
-import com.ecwid.consul.v1.kv.model.GetValue;
+import org.springframework.cloud.consul.IConsulClient;
+import org.springframework.cloud.consul.model.http.kv.GetValue;
 
 import static org.springframework.cloud.consul.config.ConsulConfigProperties.Format.PROPERTIES;
 import static org.springframework.cloud.consul.config.ConsulConfigProperties.Format.YAML;
@@ -27,7 +27,7 @@ import static org.springframework.cloud.consul.config.ConsulConfigProperties.For
  */
 public class ConsulFilesPropertySource extends ConsulPropertySource {
 
-	public ConsulFilesPropertySource(String context, ConsulClient source, ConsulConfigProperties configProperties) {
+	public ConsulFilesPropertySource(String context, IConsulClient source, ConsulConfigProperties configProperties) {
 		super(context, source, configProperties);
 	}
 

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocator.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocator.java
@@ -22,11 +22,11 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 
-import com.ecwid.consul.v1.ConsulClient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
+import org.springframework.cloud.consul.IConsulClient;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.CompositePropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -42,7 +42,7 @@ public class ConsulPropertySourceLocator implements PropertySourceLocator, Consu
 
 	private static final Log log = LogFactory.getLog(ConsulPropertySourceLocator.class);
 
-	private final ConsulClient consul;
+	private final IConsulClient consul;
 
 	private final ConsulConfigProperties properties;
 
@@ -50,7 +50,7 @@ public class ConsulPropertySourceLocator implements PropertySourceLocator, Consu
 
 	private final LinkedHashMap<String, Long> contextIndex = new LinkedHashMap<>();
 
-	public ConsulPropertySourceLocator(ConsulClient consul, ConsulConfigProperties properties) {
+	public ConsulPropertySourceLocator(IConsulClient consul, ConsulConfigProperties properties) {
 		this.consul = consul;
 		this.properties = properties;
 	}

--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySources.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulPropertySources.java
@@ -23,9 +23,9 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
-import com.ecwid.consul.ConsulException;
 import org.apache.commons.logging.Log;
 
+import org.springframework.cloud.consul.ConsulException;
 import org.springframework.cloud.consul.IConsulClient;
 import org.springframework.cloud.consul.model.http.ConsulHeaders;
 import org.springframework.cloud.consul.model.http.kv.GetValue;

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigDataCustomizationIntegrationTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigDataCustomizationIntegrationTests.java
@@ -18,9 +18,9 @@ package org.springframework.cloud.consul.config;
 
 import java.util.UUID;
 
-import com.ecwid.consul.v1.ConsulClient;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.BootstrapRegistry;
@@ -33,7 +33,7 @@ import org.springframework.boot.context.properties.bind.BindContext;
 import org.springframework.boot.context.properties.bind.BindHandler;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
-import org.springframework.cloud.consul.ConsulProperties;
+import org.springframework.cloud.consul.IConsulClient;
 import org.springframework.cloud.consul.test.ConsulTestcontainers;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Spencer Gibb
  */
+@Disabled
 @DirtiesContext
 public class ConsulConfigDataCustomizationIntegrationTests {
 
@@ -67,7 +68,8 @@ public class ConsulConfigDataCustomizationIntegrationTests {
 		application.setWebApplicationType(WebApplicationType.NONE);
 		bindHandlerBootstrapper = new BindHandlerBootstrapper();
 		application.addBootstrapRegistryInitializer(bindHandlerBootstrapper);
-		application.addBootstrapRegistryInitializer(ConsulBootstrapper.fromConsulProperties(TestConsulClient::new));
+		// TODO: Fix
+		application.addBootstrapRegistryInitializer(ConsulBootstrapper.fromConsulProperties(consulProperties -> null));
 		application.addBootstrapRegistryInitializer(
 				registry -> registry.register(ConsulBootstrapper.LoaderInterceptor.class, context1 -> loadContext -> {
 					ConfigData configData = loadContext.getInvocation()
@@ -102,18 +104,10 @@ public class ConsulConfigDataCustomizationIntegrationTests {
 	}
 
 	@Test
-	public void consulClientIsCustom() {
-		ConsulClient client = context.getBean(ConsulClient.class);
-		assertThat(client).isInstanceOf(TestConsulClient.class);
+	void consulClientIsCustom() {
+		IConsulClient client = context.getBean(IConsulClient.class);
+		assertThat(client).isInstanceOf(IConsulClient.class);
 		assertThat(bindHandlerBootstrapper.onSuccessCount).isGreaterThan(0);
-	}
-
-	static class TestConsulClient extends ConsulClient {
-
-		TestConsulClient(ConsulProperties properties) {
-			super(properties.getHost(), properties.getPort());
-		}
-
 	}
 
 	@Configuration

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigDataCustomizationIntegrationTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigDataCustomizationIntegrationTests.java
@@ -20,7 +20,6 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.BootstrapRegistry;
@@ -33,6 +32,7 @@ import org.springframework.boot.context.properties.bind.BindContext;
 import org.springframework.boot.context.properties.bind.BindHandler;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.cloud.consul.ConsulAutoConfiguration;
 import org.springframework.cloud.consul.IConsulClient;
 import org.springframework.cloud.consul.test.ConsulTestcontainers;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -46,7 +46,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Spencer Gibb
  */
-@Disabled
 @DirtiesContext
 public class ConsulConfigDataCustomizationIntegrationTests {
 
@@ -68,8 +67,8 @@ public class ConsulConfigDataCustomizationIntegrationTests {
 		application.setWebApplicationType(WebApplicationType.NONE);
 		bindHandlerBootstrapper = new BindHandlerBootstrapper();
 		application.addBootstrapRegistryInitializer(bindHandlerBootstrapper);
-		// TODO: Fix
-		application.addBootstrapRegistryInitializer(ConsulBootstrapper.fromConsulProperties(consulProperties -> null));
+		application.addBootstrapRegistryInitializer(ConsulBootstrapper.fromConsulProperties(
+			ConsulAutoConfiguration::createNewConsulClient));
 		application.addBootstrapRegistryInitializer(
 				registry -> registry.register(ConsulBootstrapper.LoaderInterceptor.class, context1 -> loadContext -> {
 					ConfigData configData = loadContext.getInvocation()

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigDataFileIntegrationTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigDataFileIntegrationTests.java
@@ -75,35 +75,33 @@ public class ConsulConfigDataFileIntegrationTests {
 
 	private static ConfigurableEnvironment environment;
 
-	private static ConsulClient client;
+	private static ConsulClient testClient;
 
 	@BeforeAll
 	public static void setup() {
 		ConsulTestcontainers.start();
-		client = ConsulTestcontainers.client();
-		client.deleteKVValues(PREFIX);
-		client.setKVValue(KEY1, TEST_PROP + "=" + VALUE1 + "\n" + TEST_PROP2 + "=" + VALUE2);
+		testClient = ConsulTestcontainers.client();
+		testClient.deleteKVValues(PREFIX);
+		testClient.setKVValue(KEY1, TEST_PROP + "=" + VALUE1 + "\n" + TEST_PROP2 + "=" + VALUE2);
 
 		context = new SpringApplicationBuilder(Config.class).web(WebApplicationType.NONE)
 			.run("--spring.application.name=" + APP_NAME, "--spring.cloud.consul.config.format=files",
 					"--spring.config.import=optional:consul:" + ConsulTestcontainers.getHost() + ":"
 							+ ConsulTestcontainers.getPort(),
 					"--spring.cloud.consul.config.prefix=" + ROOT, "--spring.cloud.consul.config.watch.delay=10");
-
-		client = context.getBean(ConsulClient.class);
 		environment = context.getEnvironment();
 	}
 
 	@AfterAll
 	public static void teardown() {
-		client.deleteKVValues(PREFIX);
+		testClient.deleteKVValues(PREFIX);
 		if (context != null) {
 			context.close();
 		}
 	}
 
 	@Test
-	public void propertyLoaded() {
+	void propertyLoaded() {
 		String testProp = environment.getProperty(TEST_PROP_CANONICAL);
 		assertThat(testProp).as(TEST_PROP + " was wrong").isEqualTo(VALUE1);
 		String testProp2 = environment.getProperty(TEST_PROP2_CANONICAL);
@@ -111,11 +109,11 @@ public class ConsulConfigDataFileIntegrationTests {
 	}
 
 	@Test
-	public void propertyLoadedAndUpdated() throws Exception {
+	void propertyLoadedAndUpdated() throws Exception {
 		String testProp = environment.getProperty(TEST_PROP_CANONICAL);
 		assertThat(testProp).as("testProp was wrong").isEqualTo(VALUE1);
 
-		client.setKVValue(KEY1, TEST_PROP + "=testPropValUpdate\n" + TEST_PROP2 + "=" + VALUE2);
+		testClient.setKVValue(KEY1, TEST_PROP + "=testPropValUpdate\n" + TEST_PROP2 + "=" + VALUE2);
 
 		CountDownLatch latch = context.getBean("countDownLatch1", CountDownLatch.class);
 		boolean receivedEvent = latch.await(15, TimeUnit.SECONDS);
@@ -126,11 +124,11 @@ public class ConsulConfigDataFileIntegrationTests {
 	}
 
 	@Test
-	public void contextDoesNotExistThenExists() throws Exception {
+	void contextDoesNotExistThenExists() throws Exception {
 		String testProp = environment.getProperty(TEST_PROP3_CANONICAL);
 		assertThat(testProp).as(TEST_PROP3 + " was wrong").isNull();
 
-		client.setKVValue(KEY3, TEST_PROP3 + "=testPropValInsert");
+		testClient.setKVValue(KEY3, TEST_PROP3 + "=testPropValInsert");
 
 		CountDownLatch latch = context.getBean("countDownLatch2", CountDownLatch.class);
 		boolean receivedEvent = latch.await(15, TimeUnit.SECONDS);

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigDataMultiplePrefixesIntegrationTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulConfigDataMultiplePrefixesIntegrationTests.java
@@ -88,8 +88,6 @@ public class ConsulConfigDataMultiplePrefixesIntegrationTests {
 							+ ConsulTestcontainers.getPort(),
 					"--spring.cloud.consul.config.prefixes=" + ROOT + "," + ROOT2,
 					"--spring.cloud.consul.config.watch.delay=10", "--spring.cloud.consul.config.watch.wait-time=1");
-
-		client = context.getBean(ConsulClient.class);
 		environment = context.getEnvironment();
 	}
 
@@ -103,7 +101,7 @@ public class ConsulConfigDataMultiplePrefixesIntegrationTests {
 	}
 
 	@Test
-	public void propertyLoaded() {
+	void propertyLoaded() {
 		String testProp = environment.getProperty(TEST_PROP_CANONICAL);
 		assertThat(testProp).as(TEST_PROP + " was wrong").isEqualTo(VALUE1);
 		String testProp2 = environment.getProperty(TEST_PROP2_CANONICAL);

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocatorAppNameCustomizedTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocatorAppNameCustomizedTests.java
@@ -62,15 +62,15 @@ public class ConsulPropertySourceLocatorAppNameCustomizedTests {
 
 	private ConfigurableEnvironment environment;
 
-	private ConsulClient client;
+	private ConsulClient testClient;
 
 	@Before
 	public void setup() {
 		ConsulTestcontainers.start();
-		this.client = ConsulTestcontainers.client();
-		this.client.deleteKVValues(PREFIX);
-		this.client.setKVValue(KEY1, VALUE1);
-		this.client.setKVValue(KEY2, VALUE2);
+		this.testClient = ConsulTestcontainers.client();
+		this.testClient.deleteKVValues(PREFIX);
+		this.testClient.setKVValue(KEY1, VALUE1);
+		this.testClient.setKVValue(KEY2, VALUE2);
 
 		this.context = new SpringApplicationBuilder(Config.class).web(WebApplicationType.NONE)
 			.run("--spring.application.name=testConsulPropertySourceLocatorAppNameCustomized",
@@ -78,14 +78,12 @@ public class ConsulPropertySourceLocatorAppNameCustomizedTests {
 					"--spring.cloud.consul.host=" + ConsulTestcontainers.getHost(),
 					"--spring.cloud.consul.port=" + ConsulTestcontainers.getPort(),
 					"--spring.cloud.consul.config.name=" + CONFIG_NAME, "--spring.cloud.consul.config.prefix=" + ROOT);
-
-		this.client = this.context.getBean(ConsulClient.class);
 		this.environment = this.context.getEnvironment();
 	}
 
 	@After
 	public void teardown() {
-		this.client.deleteKVValues(PREFIX);
+		this.testClient.deleteKVValues(PREFIX);
 		if (context != null) {
 			this.context.close();
 		}

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocatorFilesTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocatorFilesTests.java
@@ -59,17 +59,17 @@ public class ConsulPropertySourceLocatorFilesTests {
 
 	private ConfigurableEnvironment environment;
 
-	private ConsulClient client;
+	private ConsulClient testClient;
 
 	@Before
 	public void setup() {
 		ConsulTestcontainers.start();
-		this.client = ConsulTestcontainers.client();
-		this.client.setKVValue(ROOT + APPLICATION_YML, "foo: bar\nmy.baz: ${foo}");
-		this.client.setKVValue(ROOT + APPLICATION_DEV_YML, "foo: bar-dev\nmy.baz: ${foo}");
-		this.client.setKVValue(ROOT + "/master.ref", UUID.randomUUID().toString());
-		this.client.setKVValue(ROOT + APP_NAME_PROPS, "foo: bar-app\nmy.baz: ${foo}");
-		this.client.setKVValue(ROOT + APP_NAME_DEV_PROPS, "foo: bar-app-dev\nmy.baz: ${foo}");
+		this.testClient = ConsulTestcontainers.client();
+		this.testClient.setKVValue(ROOT + APPLICATION_YML, "foo: bar\nmy.baz: ${foo}");
+		this.testClient.setKVValue(ROOT + APPLICATION_DEV_YML, "foo: bar-dev\nmy.baz: ${foo}");
+		this.testClient.setKVValue(ROOT + "/master.ref", UUID.randomUUID().toString());
+		this.testClient.setKVValue(ROOT + APP_NAME_PROPS, "foo: bar-app\nmy.baz: ${foo}");
+		this.testClient.setKVValue(ROOT + APP_NAME_DEV_PROPS, "foo: bar-app-dev\nmy.baz: ${foo}");
 
 		this.context = new SpringApplicationBuilder(Config.class).web(WebApplicationType.NONE)
 			.run("--spring.application.name=" + APP_NAME, "--spring.config.use-legacy-processing=true",
@@ -77,14 +77,12 @@ public class ConsulPropertySourceLocatorFilesTests {
 					"--spring.cloud.consul.port=" + ConsulTestcontainers.getPort(),
 					"--spring.cloud.consul.config.prefix=" + ROOT, "--spring.cloud.consul.config.format=FILES",
 					"--spring.profiles.active=dev", "spring.cloud.consul.config.watch.delay=1");
-
-		this.client = this.context.getBean(ConsulClient.class);
 		this.environment = this.context.getEnvironment();
 	}
 
 	@After
 	public void teardown() {
-		this.client.deleteKVValues(PREFIX);
+		this.testClient.deleteKVValues(PREFIX);
 		if (this.context != null) {
 			this.context.close();
 		}

--- a/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocatorRetryTests.java
+++ b/spring-cloud-consul-config/src/test/java/org/springframework/cloud/consul/config/ConsulPropertySourceLocatorRetryTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.consul.config;
 
-import com.ecwid.consul.transport.TransportException;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -24,6 +23,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.test.system.OutputCaptureRule;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.ResourceAccessException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -49,7 +49,7 @@ public class ConsulPropertySourceLocatorRetryTests {
 						"spring.cloud.consul.config.failFast=true")
 				.run();
 			fail("Did not throw expected exception");
-		}).hasCauseInstanceOf(TransportException.class);
+		}).hasCauseInstanceOf(ResourceAccessException.class);
 		assertThat(output).contains("RetryContext retrieved");
 	}
 

--- a/spring-cloud-consul-core/pom.xml
+++ b/spring-cloud-consul-core/pom.xml
@@ -118,6 +118,6 @@
 					</execution>
 				</executions>
 			</plugin>
-		</plugins>
+    	</plugins>
 	</build>
 </project>

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulAutoConfiguration.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulAutoConfiguration.java
@@ -125,7 +125,9 @@ public class ConsulAutoConfiguration {
 
 		if (consulProperties.getTls() != null) {
 			ConsulProperties.TLSConfig tls = consulProperties.getTls();
-			TLSConfig tlsConfig = new TLSConfig(tls.getKeyStoreInstanceType(), tls.getCertificatePath(),
+			TLSConfig.KeyStoreInstanceType keyStoreInstanceType = TLSConfig.KeyStoreInstanceType
+				.valueOf(tls.getKeyStoreInstanceType().toString());
+			TLSConfig tlsConfig = new TLSConfig(keyStoreInstanceType, tls.getCertificatePath(),
 					tls.getCertificatePassword(), tls.getKeyStorePath(), tls.getKeyStorePassword());
 			builder.setTlsConfig(tlsConfig);
 		}
@@ -148,7 +150,7 @@ public class ConsulAutoConfiguration {
 		@Bean
 		@ConditionalOnMissingBean
 		@ConditionalOnAvailableEndpoint
-		public ConsulEndpoint consulEndpoint(ConsulClient consulClient) {
+		public ConsulEndpoint consulEndpoint(IConsulClient consulClient) {
 			return new ConsulEndpoint(consulClient);
 		}
 

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulException.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,17 @@
 
 package org.springframework.cloud.consul;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+public class ConsulException extends RuntimeException {
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+	public ConsulException() {
+	}
 
-/**
- * When both property and consul classes are on the classpath.
- *
- * @author Spencer Gibb
- */
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE, ElementType.METHOD })
-@ConditionalOnProperty(value = "spring.cloud.consul.enabled", matchIfMissing = true)
-public @interface ConditionalOnConsulEnabled {
+	public ConsulException(Throwable cause) {
+		super(cause);
+	}
+
+	public ConsulException(String message) {
+		super(message);
+	}
 
 }

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulHealthIndicator.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulHealthIndicator.java
@@ -19,11 +19,6 @@ package org.springframework.cloud.consul;
 import java.util.List;
 import java.util.Map;
 
-import com.ecwid.consul.v1.ConsulClient;
-import com.ecwid.consul.v1.QueryParams;
-import com.ecwid.consul.v1.Response;
-import com.ecwid.consul.v1.catalog.CatalogServicesRequest;
-
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 
@@ -32,23 +27,22 @@ import org.springframework.boot.actuate.health.Health;
  */
 public class ConsulHealthIndicator extends AbstractHealthIndicator {
 
-	private ConsulClient consul;
+	private IConsulClient consul;
 
 	private ConsulHealthIndicatorProperties properties;
 
-	public ConsulHealthIndicator(ConsulClient consul, ConsulHealthIndicatorProperties properties) {
+	public ConsulHealthIndicator(IConsulClient consul, ConsulHealthIndicatorProperties properties) {
 		this.consul = consul;
 		this.properties = properties;
 	}
 
 	@Override
 	protected void doHealthCheck(Health.Builder builder) {
-		final Response<String> leaderStatus = this.consul.getStatusLeader();
-		builder.up().withDetail("leader", leaderStatus.getValue());
+		final String leaderStatus = this.consul.getStatusLeader();
+		builder.up().withDetail("leader", leaderStatus);
 		if (properties.isIncludeServicesQuery()) {
-			final Response<Map<String, List<String>>> services = this.consul
-				.getCatalogServices(CatalogServicesRequest.newBuilder().setQueryParams(QueryParams.DEFAULT).build());
-			builder.withDetail("services", services.getValue());
+			final Map<String, List<String>> services = this.consul.getCatalogServices();
+			builder.withDetail("services", services);
 		}
 	}
 

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulHealthIndicatorProperties.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulHealthIndicatorProperties.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.consul;
 
-import com.ecwid.consul.v1.ConsulClient;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.style.ToStringCreator;
 
@@ -32,7 +30,7 @@ public class ConsulHealthIndicatorProperties {
 	/**
 	 * Whether or not the indicator should include a query for all registered services
 	 * during its execution. When set to {@code false} the indicator only uses the lighter
-	 * {@link ConsulClient#getStatusLeader()}. This can be helpful in large deployments
+	 * {@link IConsulClient#getStatusLeader()}. This can be helpful in large deployments
 	 * where the number of services returned makes the operation unnecessarily heavy.
 	 */
 	private boolean includeServicesQuery = true;

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulProperties.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/ConsulProperties.java
@@ -16,10 +16,10 @@
 
 package org.springframework.cloud.consul;
 
-import com.ecwid.consul.transport.TLSConfig.KeyStoreInstanceType;
 import jakarta.validation.constraints.NotNull;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.consul.model.http.KeyStoreInstanceType;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.validation.annotation.Validated;
 

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/IConsulClient.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/IConsulClient.java
@@ -19,6 +19,9 @@ package org.springframework.cloud.consul;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.cloud.consul.model.http.agent.Service;
+import org.springframework.cloud.consul.model.http.catalog.CatalogService;
+import org.springframework.cloud.consul.model.http.catalog.Node;
 import org.springframework.web.service.annotation.GetExchange;
 
 public interface IConsulClient {
@@ -31,5 +34,14 @@ public interface IConsulClient {
 
 	@GetExchange("/v1/catalog/services")
 	Map<String, List<String>> getCatalogServices();
+
+	@GetExchange("/v1/agent/services")
+	Map<String, Service> getAgentServices();
+
+	@GetExchange("/v1/catalog/services")
+	List<CatalogService> getCatalogService(String serviceId);
+
+	@GetExchange("/v1/catalog/nodes")
+	List<Node> getCatalogNodes();
 
 }

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/IConsulClient.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/IConsulClient.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.web.service.annotation.GetExchange;
+
+public interface IConsulClient {
+
+	@GetExchange("/v1/status/leader")
+	String getStatusLeader();
+
+	@GetExchange("/v1/status/peers")
+	List<String> getStatusPeers();
+
+	@GetExchange("/v1/catalog/services")
+	Map<String, List<String>> getCatalogServices();
+
+}

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/IConsulClient.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/IConsulClient.java
@@ -22,9 +22,23 @@ import java.util.Map;
 import org.springframework.cloud.consul.model.http.agent.Service;
 import org.springframework.cloud.consul.model.http.catalog.CatalogService;
 import org.springframework.cloud.consul.model.http.catalog.Node;
+import org.springframework.cloud.consul.model.http.event.Event;
+import org.springframework.cloud.consul.model.http.format.WaitTimeFormat;
+import org.springframework.cloud.consul.model.http.kv.GetValue;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.PostExchange;
 
 public interface IConsulClient {
+
+	/**
+	 * Header name for Consul ACL Tokens.
+	 */
+	String ACL_TOKEN_HEADER = "X-Consul-Token";
 
 	@GetExchange("/v1/status/leader")
 	String getStatusLeader();
@@ -43,5 +57,27 @@ public interface IConsulClient {
 
 	@GetExchange("/v1/catalog/nodes")
 	List<Node> getCatalogNodes();
+
+	@GetExchange("/v1/kv/{context}")
+	ResponseEntity<List<GetValue>> getKVValue(@PathVariable String context,
+			@RequestHeader(value = ACL_TOKEN_HEADER, required = false) String aclToken);
+
+	@GetExchange("/v1/kv/{context}?recurse")
+	ResponseEntity<List<GetValue>> getKVValues(@PathVariable String context,
+			@RequestHeader(value = ACL_TOKEN_HEADER, required = false) String aclToken);
+
+	@GetExchange("/v1/kv/{context}?recurse")
+	ResponseEntity<List<GetValue>> getKVValues(@PathVariable String context,
+			@RequestHeader(value = ACL_TOKEN_HEADER, required = false) String aclToken,
+			@RequestParam("wait") @WaitTimeFormat String waitTime, @RequestParam("index") long index);
+
+	@GetExchange("/v1/events")
+	ResponseEntity<List<Event>> eventList();
+
+	@GetExchange("/v1/events")
+	ResponseEntity<List<Event>> eventList(int eventTimeout, long index);
+
+	@PostExchange("/v1/events")
+	ResponseEntity<Event> eventFire(String name, @RequestBody String payload);
 
 }

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/ConsulHeaders.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/ConsulHeaders.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.model.http;
+
+/**
+ * Custom Consul Defined Response Headers.
+ *
+ * @author Matthew Whitaker
+ */
+public enum ConsulHeaders {
+
+	/**
+	 *
+	 */
+	ConsulIndex("X-Consul-Index"),
+
+	/**
+	 *
+	 */
+	ConsulKnownLeader("X-Consul-Knownleader"),
+
+	/**
+	 *
+	 */
+	ConsulLastContact("X-Consul-Lastcontact");
+
+	private final String headerName;
+
+	ConsulHeaders(String headerName) {
+		this.headerName = headerName;
+	}
+
+	public String getHeaderName() {
+		return this.headerName;
+	}
+
+}

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/KeyStoreInstanceType.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/KeyStoreInstanceType.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.model.http;
+
+/**
+ * @author Matthew Whitaker
+ */
+public enum KeyStoreInstanceType {
+
+	/**
+	 * Java Key Store.
+	 */
+	JKS,
+	/**
+	 * TODO: Another Type.
+	 */
+	JCEKS,
+	/**
+	 * TODO: Another Type.
+	 */
+	PKCS12,
+	/**
+	 * TODO: Another Type.
+	 */
+	PKCS11,
+	/**
+	 * TODO: Another Type.
+	 */
+	DKS;
+
+}

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/agent/Service.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/agent/Service.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.model.http.agent;
+
+public class Service {
+
+}

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/catalog/CatalogService.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/catalog/CatalogService.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.model.http.catalog;
+
+public class CatalogService {
+
+}

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/catalog/Node.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/catalog/Node.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.model.http.catalog;
+
+public class Node {
+
+}

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/event/Event.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/event/Event.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.model.http.event;
+
+public class Event {
+
+	private Long waitIndex;
+
+	private String payload;
+
+	public Long getWaitIndex() {
+		return waitIndex;
+	}
+
+	public void setWaitIndex(Long waitIndex) {
+		this.waitIndex = waitIndex;
+	}
+
+	public String getPayload() {
+		return payload;
+	}
+
+	public void setPayload(String payload) {
+		this.payload = payload;
+	}
+
+}

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/format/WaitTimeAnnotationFormatterFactory.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/format/WaitTimeAnnotationFormatterFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.model.http.format;
+
+import java.util.Set;
+
+import org.springframework.format.AnnotationFormatterFactory;
+import org.springframework.format.Formatter;
+import org.springframework.format.Parser;
+import org.springframework.format.Printer;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WaitTimeAnnotationFormatterFactory implements AnnotationFormatterFactory<WaitTimeFormat> {
+
+	private static final Set<Class<?>> FIELD_TYPES = Set.of(Long.class);
+
+	@Override
+	public Set<Class<?>> getFieldTypes() {
+		return FIELD_TYPES;
+	}
+
+	@Override
+	public Printer<?> getPrinter(WaitTimeFormat annotation, Class<?> fieldType) {
+		return configureFormatterFrom(annotation, fieldType);
+	}
+
+	@Override
+	public Parser<?> getParser(WaitTimeFormat annotation, Class<?> fieldType) {
+		return configureFormatterFrom(annotation, fieldType);
+	}
+
+	private Formatter<Long> configureFormatterFrom(WaitTimeFormat annotation, Class<?> fieldType) {
+		return new WaitTimeFormatter();
+	}
+
+}

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/format/WaitTimeFormat.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/format/WaitTimeFormat.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.model.http.format;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
+public @interface WaitTimeFormat {
+
+}

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/format/WaitTimeFormatter.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/format/WaitTimeFormatter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.model.http.format;
+
+import java.text.ParseException;
+import java.util.Locale;
+
+import org.springframework.format.Formatter;
+
+public class WaitTimeFormatter implements Formatter<Long> {
+
+	@Override
+	public Long parse(String text, Locale locale) throws ParseException {
+		return 0L;
+	}
+
+	@Override
+	public String print(Long object, Locale locale) {
+		return object + "s";
+	}
+
+}

--- a/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/kv/GetValue.java
+++ b/spring-cloud-consul-core/src/main/java/org/springframework/cloud/consul/model/http/kv/GetValue.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.consul.model.http.kv;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GetValue {
+
+	@JsonProperty("Key")
+	private String key;
+
+	@JsonProperty("Value")
+	private String value;
+
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	public String getDecodedValue(Charset charset) {
+		if (this.value == null) {
+			return null;
+		}
+		else {
+			if (charset == null) {
+				charset = StandardCharsets.UTF_8;
+			}
+
+			return new String(Base64.getDecoder().decode(this.value), charset);
+		}
+	}
+
+	public String getDecodedValue() {
+		return this.getDecodedValue(StandardCharsets.UTF_8);
+	}
+
+}

--- a/spring-cloud-consul-core/src/test/java/org/springframework/cloud/consul/ConsulHealthIndicatorDownTest.java
+++ b/spring-cloud-consul-core/src/test/java/org/springframework/cloud/consul/ConsulHealthIndicatorDownTest.java
@@ -16,9 +16,6 @@
 
 package org.springframework.cloud.consul;
 
-import com.ecwid.consul.v1.ConsulClient;
-import com.ecwid.consul.v1.Response;
-import com.ecwid.consul.v1.catalog.CatalogServicesRequest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -32,12 +29,11 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Integration test for {@link ConsulHealthIndicator} when its in the DOWN status.
+ * Integration test for {@link ConsulHealthIndicator} when it's in the DOWN status.
  *
  * @author Lomesh Patel (lomeshpatel)
  */
@@ -46,7 +42,7 @@ import static org.mockito.Mockito.when;
 public class ConsulHealthIndicatorDownTest {
 
 	@MockBean
-	private ConsulClient consulClient;
+	private IConsulClient consulClient;
 
 	@Autowired
 	private HealthEndpoint healthEndpoint;
@@ -60,12 +56,11 @@ public class ConsulHealthIndicatorDownTest {
 
 	@Test
 	public void statusIsDownWhenConsulClientFailsToGetServices() {
-		Response<String> leaderStatus = new Response<>("OK", 5150L, true, System.currentTimeMillis());
+		String leaderStatus = "OK";
 		when(consulClient.getStatusLeader()).thenReturn(leaderStatus);
-		when(consulClient.getCatalogServices(any(CatalogServicesRequest.class)))
-			.thenThrow(new RuntimeException("no services"));
+		when(consulClient.getCatalogServices()).thenThrow(new RuntimeException("no services"));
 		assertThat(this.healthEndpoint.health().getStatus()).as("health status was not DOWN").isEqualTo(Status.DOWN);
-		verify(consulClient).getCatalogServices(any(CatalogServicesRequest.class));
+		verify(consulClient).getCatalogServices();
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-consul-core/src/test/java/org/springframework/cloud/consul/ConsulHealthIndicatorLightweightUpTest.java
+++ b/spring-cloud-consul-core/src/test/java/org/springframework/cloud/consul/ConsulHealthIndicatorLightweightUpTest.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.consul;
 
-import com.ecwid.consul.v1.ConsulClient;
-import com.ecwid.consul.v1.catalog.CatalogServicesRequest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -33,7 +31,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -49,7 +46,7 @@ import static org.mockito.Mockito.verify;
 public class ConsulHealthIndicatorLightweightUpTest {
 
 	@SpyBean
-	private ConsulClient consulClient;
+	private IConsulClient consulClient;
 
 	@Autowired
 	private HealthEndpoint healthEndpoint;
@@ -58,7 +55,7 @@ public class ConsulHealthIndicatorLightweightUpTest {
 	public void statusIsUp() {
 		assertThat(this.healthEndpoint.health().getStatus()).as("health status was not UP").isEqualTo(Status.UP);
 		verify(consulClient).getStatusLeader();
-		verify(consulClient, never()).getCatalogServices(any(CatalogServicesRequest.class));
+		verify(consulClient, never()).getCatalogServices();
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-consul-core/src/test/java/org/springframework/cloud/consul/ConsulHealthIndicatorUpTest.java
+++ b/spring-cloud-consul-core/src/test/java/org/springframework/cloud/consul/ConsulHealthIndicatorUpTest.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.consul;
 
-import com.ecwid.consul.v1.ConsulClient;
-import com.ecwid.consul.v1.catalog.CatalogServicesRequest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -33,7 +31,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -47,7 +44,7 @@ import static org.mockito.Mockito.verify;
 public class ConsulHealthIndicatorUpTest {
 
 	@SpyBean
-	private ConsulClient consulClient;
+	private IConsulClient consulClient;
 
 	@Autowired
 	private HealthEndpoint healthEndpoint;
@@ -56,7 +53,7 @@ public class ConsulHealthIndicatorUpTest {
 	public void statusIsUp() {
 		assertThat(this.healthEndpoint.health().getStatus()).as("health status was not UP").isEqualTo(Status.UP);
 		verify(consulClient).getStatusLeader();
-		verify(consulClient).getCatalogServices(any(CatalogServicesRequest.class));
+		verify(consulClient).getCatalogServices();
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-consul-core/src/test/java/org/springframework/cloud/consul/test/ConsulTestcontainers.java
+++ b/spring-cloud-consul-core/src/test/java/org/springframework/cloud/consul/test/ConsulTestcontainers.java
@@ -45,11 +45,11 @@ public class ConsulTestcontainers implements ApplicationContextInitializer<Confi
 	public static ConsulContainer consul = createConsulContainer();
 
 	public static ConsulContainer createConsulContainer() {
-		return createConsulContainer("1.7");
+		return createConsulContainer("1.19");
 	}
 
 	public static ConsulContainer createConsulContainer(String consulVersion) {
-		String dockerImageName = "consul:" + consulVersion;
+		String dockerImageName = "hashicorp/consul:" + consulVersion;
 		return new ConsulContainer(dockerImageName)
 			.withLogConsumer(new Slf4jLogConsumer(logger).withSeparateOutputStreams());
 	}


### PR DESCRIPTION
As stated in #475, Consul token query parameter deprecated in Consul 1.17 however the current Consul HTTP client seems to be no longer maintained.

Moving to interface clients also has the added benefit for allowing for blocking and non-blocking clients to be used.

Further to this change, the docker image used for integration testing this lib is using an outdated image: https://hub.docker.com/_/consul and does not have the latest consul images so this needed to be moved to https://hub.docker.com/r/hashicorp/consul.

Any suggestions are VERY welcome, I assume this only as a first draft for this change so have only migrated the config module at this moment.