### PR TITLE
NOISSUE: Fix documentation link for Consul agent

### DIFF
--- a/docs/src/main/asciidoc/sagan-index.adoc
+++ b/docs/src/main/asciidoc/sagan-index.adoc
@@ -36,4 +36,4 @@ public class Application {
 }
 ```
 
-A local Consul agent must be running.  See the https://consul.io/docs/agent/basics.html[Consul agent documentation] on how to run an agent.
+A local Consul agent must be running.  See the https://developer.hashicorp.com/consul/docs/agent#starting-the-consul-agent[Consul agent documentation] on how to run an agent.


### PR DESCRIPTION
Link for Consul agent on https://spring.io/projects/spring-cloud-consul routes to a 404
<img width="1433" alt="image" src="https://github.com/user-attachments/assets/c3043ca1-bb17-4879-b041-b08a6897e7ed" />

This code change fixes the link & updates it to use https://developer.hashicorp.com/consul/docs/agent#starting-the-consul-agent for Consul agent