### PR TITLE
Enable masking ACL token in the logs

### DIFF
--- a/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
+++ b/spring-cloud-consul-config/src/main/java/org/springframework/cloud/consul/config/ConsulConfigProperties.java
@@ -197,7 +197,7 @@ public class ConsulConfigProperties {
 			.append("profileSeparator", this.profileSeparator)
 			.append("format", this.format)
 			.append("dataKey", this.dataKey)
-			.append("aclToken", this.aclToken)
+			.append("aclToken", this.aclToken != null ? "******" : null)
 			.append("watch", this.watch)
 			.append("failFast", this.failFast)
 			.append("name", this.name)


### PR DESCRIPTION
When there is a problem with pulling consul configs, it happens that ACL token is logged together with other parameters:


```
***************************
APPLICATION FAILED TO START
***************************

Description:

Config data resource '[ConsulConfigDataResource@b78a709 context = 'config/${project}/kafkaconsumer/application-default/', optional = true, properties = [ConsulConfigProperties@30bcf3c1 enabled = true, prefixes = list['config/${project}/kafkaconsumer'], defaultContext = 'application', profileSeparator = '-', format = YAML, dataKey = 'data', aclToken = 'demo-acl-token', watch = [ConsulConfigProperties.Watch@2a3c96e3 waitTime = 55, enabled = true, delay = 1000], failFast = true, name = 'application'], profile = 'default']' via location 'consul:/' does not exist

Action:

Check that the value 'consul:/' at class path resource [application.yml] - 33:9 is correct, or prefix it with 'optional:'
```

You can see `acl-token='demo-acl-token'` in the output above.

For the context, the same concern was reported in libraries of other languages/tools as well:
- hashi-ui: ACL tokens are logged to console/docker output [#600](https://github.com/jippi/hashi-ui/issues/600)
- traefik: Traefik is logging the Consul ACL token [#8698](https://github.com/traefik/traefik/issues/8698)


In this PR, I added a new boolean field `aclTokenMasked` which is `true` by default and prints `"<masked>"` whenever it is true, otherwise it prints the acl token in case it is needed to be logged, for example for troubleshooting purposes. Adopted this approach from Hikari CP that [uses the same `"<masked>"` string](https://github.com/brettwooldridge/HikariCP/blob/b2c8bb057532a657b1966232284ab35bb94d703f/src/main/java/com/zaxxer/hikari/HikariConfig.java#L1161).